### PR TITLE
Add groupingHash support

### DIFF
--- a/src/main/java/com/bugsnag/Client.java
+++ b/src/main/java/com/bugsnag/Client.java
@@ -97,6 +97,14 @@ public class Client {
         config.setLogger(logger);
     }
 
+    public void setGroupingHashCallback(GroupingHashCallback groupingHashCallback) {
+        config.setGroupingHashCallback(groupingHashCallback);
+    }
+
+    public void setGroupingHash(String groupingHash) {
+        config.setGroupingHash(groupingHash);
+    }
+
     public void notify(Error error) {
         if(!config.shouldNotify()) return;
         if(error.shouldIgnore()) return;

--- a/src/main/java/com/bugsnag/Configuration.java
+++ b/src/main/java/com/bugsnag/Configuration.java
@@ -58,6 +58,10 @@ public class Configuration {
     String[] projectPackages;
     String[] ignoreClasses;
 
+    // Grouping Hash settings
+    GroupingHashCallback groupingHashCallback;
+    String groupingHash;
+
     // Error settings
     LockableValue<String> context = new LockableValue<String>();
     LockableValue<String> releaseStage = new LockableValue<String>("production");
@@ -178,5 +182,21 @@ public class Configuration {
 
     public void setLogger(Logger logger) {
         this.logger = logger;
+    }
+
+    public void setGroupingHashCallback(GroupingHashCallback groupingHashCallback) {
+        this.groupingHashCallback = groupingHashCallback;
+    }
+
+    public void setGroupingHash(String groupingHash) {
+        this.groupingHash = groupingHash;
+    }
+
+    public GroupingHashCallback getGroupingHashCallback() {
+        return groupingHashCallback;
+    }
+
+    public String getGroupingHash() {
+        return groupingHash;
     }
 }

--- a/src/main/java/com/bugsnag/Error.java
+++ b/src/main/java/com/bugsnag/Error.java
@@ -47,6 +47,28 @@ public class Error {
 
         JSONUtils.safePut(error, "payloadVersion", payloadVersion);
 
+        String groupingHash = null;
+
+        // If a grouping hash is provided, us it as a default
+        if (config.getGroupingHash() != null) {
+            groupingHash = config.getGroupingHash();
+        }
+
+        GroupingHashCallback groupingHasher = config.getGroupingHashCallback();
+        if (groupingHasher != null) {
+            try {
+                // Attempt at retrieving a groupingHash from the callback
+                groupingHash = groupingHasher.run(exception);
+            } catch(Throwable e) {
+                // Here to prevent infinite loop
+                e.printStackTrace(System.err);
+            }
+        }
+
+        if (groupingHash != null) {
+            JSONUtils.safePut(error, "groupingHash", groupingHash);
+        }
+
         // Unwrap exceptions
         JSONArray exceptions = new JSONArray();
         Throwable currentEx = this.exception;

--- a/src/main/java/com/bugsnag/GroupingHashCallback.java
+++ b/src/main/java/com/bugsnag/GroupingHashCallback.java
@@ -1,0 +1,5 @@
+package com.bugsnag;
+
+public interface GroupingHashCallback {
+    abstract String run(Throwable error);
+}


### PR DESCRIPTION
Constructive criticism is welcome.

I've added an option to provide a `GroupingHashCallback`, which accepts the original `Throwable`, and is given the option to generate a `groupingHash` from it.

Not sure if this is really required, as a Javascript developer, I'm used to having the option to provide a callback, but maybe this isn't really appropriate.

Regards,
Jacob
