### PR TITLE
Add configurable connection and read timeouts

### DIFF
--- a/src/main/java/com/bugsnag/Configuration.java
+++ b/src/main/java/com/bugsnag/Configuration.java
@@ -60,6 +60,10 @@ public class Configuration {
     String[] ignoreClasses;
     boolean sendThreads = false;
 
+    // Connection settings, default timeout 60 seconds
+    int connectionTimeout = 60000;
+    int readTimeout = 60000;
+
     // Before notify settings
     List<BeforeNotify> beforeNotify = new LinkedList<BeforeNotify>();
 
@@ -191,5 +195,21 @@ public class Configuration {
 
     public void addBeforeNotify(BeforeNotify beforeNotify) {
         this.beforeNotify.add(beforeNotify);
+    }
+
+    public int getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public void setConnectionTimeout(int connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    public int getReadTimeout() {
+        return readTimeout;
+    }
+
+    public void setReadTimeout(int readTimeout) {
+        this.readTimeout = readTimeout;
     }
 }

--- a/src/main/java/com/bugsnag/Metrics.java
+++ b/src/main/java/com/bugsnag/Metrics.java
@@ -10,16 +10,18 @@ import com.bugsnag.utils.JSONUtils;
 public class Metrics {
     private Configuration config;
     private Diagnostics diagnostics;
+    private HttpClient httpClient;
 
     public Metrics(Configuration config, Diagnostics diagnostics) {
         this.config = config;
         this.diagnostics = diagnostics;
+        this.httpClient = new HttpClient(config);
     }
 
     public void deliver() throws NetworkException {
         String url = config.getMetricsEndpoint();
         try {
-            HttpClient.post(url, this.toString(), "application/json");
+            httpClient.post(url, this.toString(), "application/json");
         } catch(java.io.UnsupportedEncodingException e) {
             config.logger.warn("Bugsnag unable to send metrics", e);
         }

--- a/src/main/java/com/bugsnag/Notification.java
+++ b/src/main/java/com/bugsnag/Notification.java
@@ -23,13 +23,14 @@ import com.bugsnag.utils.JSONUtils;
 
 public class Notification {
     private Configuration config;
+    private HttpClient httpClient;
     ByteArrayInputStream firstNotificationStream = null;
     ByteArrayInputStream secondNotificationStream = null;
     InputStream errorStream;
 
     public Notification(Configuration config) {
         this.config = config;
-
+        this.httpClient = new HttpClient(config);
         // Outer payload
         JSONObject notification = new JSONObject();
         JSONUtils.safePut(notification, "apiKey", config.apiKey);
@@ -94,7 +95,7 @@ public class Notification {
             SequenceInputStream sis = new SequenceInputStream(enu);
 
             String url = config.getNotifyEndpoint();
-            HttpClient.post(url, sis, "application/json");
+            httpClient.post(url, sis, "application/json");
 
             config.logger.info(String.format("Sent 1 error to Bugsnag (%s)", url));
 

--- a/src/main/java/com/bugsnag/http/HttpClient.java
+++ b/src/main/java/com/bugsnag/http/HttpClient.java
@@ -9,26 +9,36 @@ import java.net.URL;
 import java.io.InputStream;
 
 import org.json.JSONObject;
-import org.json.JSONException;
+
+import com.bugsnag.Configuration;
 
 public class HttpClient {
-    public static void post(String url, InputStream stream) throws NetworkException {
+
+    private Configuration config;
+
+    public HttpClient(Configuration config) {
+        this.config = config;
+    }
+
+    public void post(String url, InputStream stream) throws NetworkException {
         post(url, stream, "application/json");
     }
 
-    public static void post(String url, JSONObject payload) throws NetworkException, UnsupportedEncodingException {
+    public void post(String url, JSONObject payload) throws NetworkException, UnsupportedEncodingException {
         post(url, payload.toString(), "application/json");
     }
 
-    public static void post(String url, String payload, String contentType) throws NetworkException, UnsupportedEncodingException {
+    public void post(String url, String payload, String contentType) throws NetworkException, UnsupportedEncodingException {
         post(url, new ByteArrayInputStream(payload.getBytes("UTF-8")), contentType);
     }
 
-    public static void post(String urlString, InputStream payload, String contentType) throws NetworkException {
+    public void post(String urlString, InputStream payload, String contentType) throws NetworkException {
         HttpURLConnection conn = null;
         try {
             URL url = new URL(urlString);
             conn = (HttpURLConnection) url.openConnection();
+            conn.setConnectTimeout(config.getConnectionTimeout());
+            conn.setReadTimeout(config.getReadTimeout());
             conn.setDoOutput(true); 
             conn.setChunkedStreamingMode(0);
 

--- a/src/test/java/com/bugsnag/http/HttpClientTest.java
+++ b/src/test/java/com/bugsnag/http/HttpClientTest.java
@@ -1,0 +1,60 @@
+package com.bugsnag.http;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.bugsnag.Configuration;
+
+import static org.junit.Assert.assertEquals;
+
+public class HttpClientTest {
+
+  Configuration configuration = new Configuration();
+  HttpClient httpClient = new HttpClient(configuration);
+
+  ServerSocket serverSocket;
+
+  @Before
+  public void setUp() throws IOException {
+    // create server with random port and room for single connection
+    serverSocket = new ServerSocket(0, 1);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    serverSocket.close();
+  }
+
+  @Ignore("behavior simulating read timeout isn't consistent across platforms")
+  @Test
+  public void testConnectionTimeout() throws Exception {
+    configuration.setConnectionTimeout(10);
+
+    // reserve the only available connection
+    new Socket().connect(serverSocket.getLocalSocketAddress());
+
+    try {
+      httpClient.post("http://localhost:" + serverSocket.getLocalPort(), new ByteArrayInputStream("foo".getBytes()));
+    } catch (NetworkException e) {
+      assertEquals("connect timed out", e.getCause().getMessage());
+    }
+  }
+
+  @Test
+  public void testReadTimeout() throws Exception {
+    configuration.setReadTimeout(10);
+
+    try {
+      httpClient.post("http://localhost:" + serverSocket.getLocalPort(), new ByteArrayInputStream("foo".getBytes()));
+    } catch (NetworkException e) {
+      assertEquals("Read timed out", e.getCause().getMessage());
+    }
+  }
+}


### PR DESCRIPTION
I was toying with a Bugsnag logback appender which was calling client.notify inside the synchronized append method. Thread dump showed one thread stuck in `int status = conn.getResponseCode();` inside HttpClient, and a few hundred threads waiting for it to release the lock it was holding.

Apparently if not configured, the connect and read timeouts are infinite. I added 60s defaults and tried to make them configurable. Let me know what you think.