### PR TITLE
Bugsnag httpclient allow set proxy

### DIFF
--- a/src/main/java/com/bugsnag/Configuration.java
+++ b/src/main/java/com/bugsnag/Configuration.java
@@ -1,5 +1,6 @@
 package com.bugsnag;
 
+import java.net.Proxy;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -60,6 +61,9 @@ public class Configuration {
     String[] ignoreClasses;
     boolean sendThreads = false;
 
+    //Proxy, optional, default null
+    Proxy proxy = null;
+
     // Connection settings, default timeout 60 seconds
     int connectionTimeout = 60000;
     int readTimeout = 60000;
@@ -73,7 +77,6 @@ public class Configuration {
     LockableValue<String> appVersion = new LockableValue<String>();
     LockableValue<String> osVersion = new LockableValue<String>();
     MetaData metaData = new MetaData();
-
     // User settings
     public JSONObject user = new JSONObject();
 
@@ -147,6 +150,14 @@ public class Configuration {
 
     public void setNotifyReleaseStages(String... notifyReleaseStages) {
         this.notifyReleaseStages = notifyReleaseStages;
+    }
+
+    public Proxy getProxy(){
+        return this.proxy;
+    }
+
+    public void setProxy(Proxy proxy){
+        this.proxy = proxy;
     }
 
     public void setAutoNotify(boolean autoNotify) {

--- a/src/main/java/com/bugsnag/http/HttpClient.java
+++ b/src/main/java/com/bugsnag/http/HttpClient.java
@@ -36,10 +36,12 @@ public class HttpClient {
         HttpURLConnection conn = null;
         try {
             URL url = new URL(urlString);
-            conn = (HttpURLConnection) url.openConnection();
+            conn = config.getProxy() != null ?
+                    (HttpURLConnection) url.openConnection(config.getProxy()) :
+                    (HttpURLConnection) url.openConnection();
             conn.setConnectTimeout(config.getConnectionTimeout());
             conn.setReadTimeout(config.getReadTimeout());
-            conn.setDoOutput(true); 
+            conn.setDoOutput(true);
             conn.setChunkedStreamingMode(0);
 
             // Set the content type header
@@ -50,7 +52,7 @@ public class HttpClient {
             OutputStream out = null;
             try {
                 out = conn.getOutputStream();
-            
+
                 // Send request headers and body
                 byte[] buffer = new byte[1024];
                 int bytesRead;

--- a/src/test/java/com/bugsnag/http/HttpClientTest.java
+++ b/src/test/java/com/bugsnag/http/HttpClientTest.java
@@ -2,8 +2,7 @@ package com.bugsnag.http;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.net.ServerSocket;
-import java.net.Socket;
+import java.net.*;
 
 import org.junit.After;
 import org.junit.Before;
@@ -55,6 +54,18 @@ public class HttpClientTest {
       httpClient.post("http://localhost:" + serverSocket.getLocalPort(), new ByteArrayInputStream("foo".getBytes()));
     } catch (NetworkException e) {
       assertEquals("Read timed out", e.getCause().getMessage());
+    }
+  }
+
+  @Test
+  public void testProxyConnection() throws Exception {
+    Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("notSoLocalHost", 8080));
+    configuration.setProxy(proxy);
+
+    try{
+      httpClient.post("http://localhost:" + serverSocket.getLocalPort(), new ByteArrayInputStream("foo".getBytes()));
+    } catch (NetworkException e){
+      assertEquals("notSoLocalHost", e.getCause().getMessage());
     }
   }
 }

--- a/src/test/java/com/bugsnag/http/HttpClientTest.java
+++ b/src/test/java/com/bugsnag/http/HttpClientTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import com.bugsnag.Configuration;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class HttpClientTest {
 
@@ -64,6 +65,7 @@ public class HttpClientTest {
 
     try{
       httpClient.post("http://localhost:" + serverSocket.getLocalPort(), new ByteArrayInputStream("foo".getBytes()));
+      fail("Should throw Exception because proxy host is unknown.");
     } catch (NetworkException e){
       assertEquals("notSoLocalHost", e.getCause().getMessage());
     }


### PR DESCRIPTION
Allowing the httpClient to use a proxy to send notifications to the bugsnag API.
