### PR TITLE
Use SSL by default for communications with Bugsnag.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,14 @@ Sets the proxy to use when sending requests to Bugsnag.com.
 bugsnag.setProxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress("example.com", 80));
 ```
 
+### setUseSSL
+
+Set whether communication with Bugsnag.com should be made via SSL. To use HTTP set it to false.
+
+```java
+bugsnag.setUseSSL(false);
+```
+
 ###setIgnoreClasses
 
 Sets for which exception classes we should not send exceptions to Bugsnag.

--- a/src/main/java/com/bugsnag/Configuration.java
+++ b/src/main/java/com/bugsnag/Configuration.java
@@ -53,7 +53,7 @@ public class Configuration {
     // Notification settings
     String apiKey;
     boolean autoNotify = true;
-    boolean useSSL = false;
+    boolean useSSL = true;
     String endpoint = DEFAULT_ENDPOINT;
     String[] notifyReleaseStages = null;
     String[] filters = new String[]{"password"};


### PR DESCRIPTION
Changes the default to SSL in line with other notifiers and highlights the ability to change it in the documentation.