### PR TITLE
Truncate very long payloads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Building and running the test requires [Maven](https://maven.apache.org). To
 test, run:
 
 ```
-maven test
+mvn test
 ```
 
 ## Making a Release

--- a/src/main/java/com/bugsnag/utils/JSONUtils.java
+++ b/src/main/java/com/bugsnag/utils/JSONUtils.java
@@ -9,6 +9,10 @@ import org.json.JSONObject;
 import org.json.JSONException;
 
 public class JSONUtils {
+
+    /** Maximum length of an individual string value */
+    private static int MAX_STRING_LENGTH = 4096;
+
     public static void safePut(JSONObject obj, String key, Object val) {
         try {
             obj.put(key, objectForJSON(val));
@@ -126,8 +130,17 @@ public class JSONUtils {
                 dest.put(objectForJSON(val));
             }
             return dest;
+        } else if(value instanceof String) {
+            return limitStringLength((String) value);
         } else {
             return value;
         }
+    }
+
+    private static String limitStringLength(String value) {
+        if (value == null || value.length() <= MAX_STRING_LENGTH) {
+            return value;
+        }
+        return value.substring(0, MAX_STRING_LENGTH) + "[TRUNCATED]";
     }
 }

--- a/src/test/java/com/bugsnag/utils/JSONUtilsTest.java
+++ b/src/test/java/com/bugsnag/utils/JSONUtilsTest.java
@@ -150,4 +150,43 @@ public class JSONUtilsTest {
 		assertThat(returnValue.optJSONArray("array"), is(instanceOf(JSONArray.class)));
 		assertThat(returnValue.optJSONArray("array").optString(0), is("array"));
 	}
+
+	@Test
+	public void testValuesTruncated() {
+		String returnValue = (String)JSONUtils.objectForJSON(generateTestString(10000));
+
+        String truncatedSuffix = "[TRUNCATED]";
+        assertEquals(4096 + truncatedSuffix.length(), returnValue.length());
+        assertThat(returnValue, endsWith(truncatedSuffix));
+	}
+
+    @Test
+    public void testMultipleValuesTruncated() {
+        HashMap<String, Object> embeddedMap = new HashMap<String, Object>();
+        embeddedMap.put("mapKey", generateTestString(10000));
+
+        ArrayList<String> embeddedArrayList = new ArrayList<String>();
+        embeddedArrayList.add(generateTestString(10000));
+
+        String[] embeddedArray = new String[] { generateTestString(10000) };
+
+        HashMap<String, Object> rootMap = new HashMap<String, Object>();
+        rootMap.put("map", embeddedMap);
+        rootMap.put("arrayList", embeddedArrayList);
+        rootMap.put("array", embeddedArray);
+        rootMap.put("string", generateTestString(10000));
+
+        JSONObject returnValue = (JSONObject)JSONUtils.objectForJSON(rootMap);
+
+        // Contains four large strings truncated to 4096 characters
+        assertEquals(16491, returnValue.toString().length());
+    }
+
+    private String generateTestString(int length) {
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++){
+            sb.append("A");
+        }
+        return sb.toString();
+    }
 }


### PR DESCRIPTION
Truncate very long payloads which will get rejected by Bugsnag with a 400 response.

Long values from the payload are limited in length and the string "[TRUNCATED]" is appended.  This is the same strategy used by the Bugsnag Ruby notifier - see:
https://github.com/bugsnag/bugsnag-ruby/blob/eb782074fa127bb6ede77f31347672f65591489c/lib/bugsnag/helpers.rb#L16