### PR TITLE
Added a thread pool to allow asynchronous notification to Bugsnag

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,16 @@ Set whether communication with Bugsnag.com should be made via SSL. To use HTTP s
 bugsnag.setUseSSL(false);
 ```
 
+###setAsynchronousNotification
+
+Sets whether error notifications to Bugsnag.com are sent asynchronously.
+
+By default `asynchronousNotification` is set to `true`.
+
+```java
+bugsnag.setAsynchronousNotification(false);
+```
+
 ###setIgnoreClasses
 
 Sets for which exception classes we should not send exceptions to Bugsnag.
@@ -246,16 +256,6 @@ Bt default `sendThreads` is set to `false`.
 
 ```java
 bugsnag.setSendThreads(true);
-```
-
-###setAsynchronousNotification
-
-Sets if we should notify Bugsnag of exceptions asynchronously.
-
-Bt default `asynchronousNotification` is set to `true`.
-
-```java
-bugsnag.setAsynchronousNotification(false);
 ```
 
 ###addBeforeNotify

--- a/README.md
+++ b/README.md
@@ -248,6 +248,16 @@ Bt default `sendThreads` is set to `false`.
 bugsnag.setSendThreads(true);
 ```
 
+###setAsynchronousNotification
+
+Sets if we should notify Bugsnag of exceptions asynchronously.
+
+Bt default `asynchronousNotification` is set to `true`.
+
+```java
+bugsnag.setAsynchronousNotification(false);
+```
+
 ###addBeforeNotify
 
 Adds a callback, in which to invoke directly before the notifier sends the

--- a/src/main/java/com/bugsnag/Configuration.java
+++ b/src/main/java/com/bugsnag/Configuration.java
@@ -60,6 +60,7 @@ public class Configuration {
     String[] projectPackages;
     String[] ignoreClasses;
     boolean sendThreads = false;
+    boolean asynchronousNotification = true;
 
     //Proxy, optional, default null
     Proxy proxy = null;
@@ -202,6 +203,10 @@ public class Configuration {
 
     public void setSendThreads(boolean sendThreads) {
         this.sendThreads = sendThreads;
+    }
+
+    public void setAsynchronousNotification(boolean asynchronousNotification) {
+        this.asynchronousNotification = asynchronousNotification;
     }
 
     public void addBeforeNotify(BeforeNotify beforeNotify) {

--- a/src/main/java/com/bugsnag/Notification.java
+++ b/src/main/java/com/bugsnag/Notification.java
@@ -81,27 +81,39 @@ public class Notification {
         }
     }
 
-    public void deliver() throws NetworkException {
-        if(errorStream != null && firstNotificationStream != null && secondNotificationStream != null) {
-            firstNotificationStream.reset();
-            secondNotificationStream.reset();
+    public void deliver() {
+        try {
+            if (errorStream != null && firstNotificationStream != null && secondNotificationStream != null) {
+                firstNotificationStream.reset();
+                secondNotificationStream.reset();
 
-            Vector<InputStream> inputStreams = new Vector<InputStream>();
-            inputStreams.add(firstNotificationStream);
-            inputStreams.add(errorStream);
-            inputStreams.add(secondNotificationStream);
+                Vector<InputStream> inputStreams = new Vector<InputStream>();
+                inputStreams.add(firstNotificationStream);
+                inputStreams.add(errorStream);
+                inputStreams.add(secondNotificationStream);
 
-            Enumeration<InputStream> enu = inputStreams.elements();
-            SequenceInputStream sis = new SequenceInputStream(enu);
+                Enumeration<InputStream> enu = inputStreams.elements();
+                SequenceInputStream sis = new SequenceInputStream(enu);
 
-            String url = config.getNotifyEndpoint();
-            httpClient.post(url, sis, "application/json");
+                String url = config.getNotifyEndpoint();
+                httpClient.post(url, sis, "application/json");
 
-            config.logger.info(String.format("Sent 1 error to Bugsnag (%s)", url));
+                config.logger.info(String.format("Sent 1 error to Bugsnag (%s)", url));
 
-            try { sis.close(); } catch (java.io.IOException e){config.logger.warn("Unable to close stream in bugsnag", e);}
-            try { errorStream.close(); } catch (java.io.IOException e){config.logger.warn("Unable to close stream in bugsnag", e);}
-            errorStream = null;
+                try {
+                    sis.close();
+                } catch (java.io.IOException e) {
+                    config.logger.warn("Unable to close stream in bugsnag", e);
+                }
+                try {
+                    errorStream.close();
+                } catch (java.io.IOException e) {
+                    config.logger.warn("Unable to close stream in bugsnag", e);
+                }
+                errorStream = null;
+            }
+        } catch (NetworkException ex) {
+            config.logger.warn("Error notifying Bugsnag", ex);
         }
     }
 }

--- a/src/main/java/com/bugsnag/NotificationWorker.java
+++ b/src/main/java/com/bugsnag/NotificationWorker.java
@@ -1,0 +1,72 @@
+package com.bugsnag;
+
+import java.util.List;
+import java.util.concurrent.*;
+
+/**
+ * Handles notifications to Bugsnag using a thread pool to manage asynchronous notification
+ */
+public class NotificationWorker {
+    // The time to wait for the notification worker threads to complete before being terminated during shutdown
+    final long WORKER_SHUTDOWN_TIMEOUT = TimeUnit.SECONDS.toMillis(1);
+
+    protected ExecutorService notifyPool;
+
+    private Configuration config;
+
+    public NotificationWorker(Configuration configuration) {
+        this.config = configuration;
+
+        // Create a thread pool with 2 daemon worker threads that queues up notifications if all threads are in use
+        notifyPool = Executors.newFixedThreadPool(2, new ThreadFactory() {
+            public Thread newThread(Runnable r) {
+                Thread t = new Thread(r);
+                t.setName("bugsnag-notification-worker");
+                t.setDaemon(true);
+                return t;
+            }
+        });
+
+        // Add a shutdown hook to try to gracefully complete all pending error notifications
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                notifyPool.shutdown();
+                try {
+                    // Attempt to gracefully terminate the currently processing notification threads
+                    if (!notifyPool.awaitTermination(WORKER_SHUTDOWN_TIMEOUT, TimeUnit.MILLISECONDS)) {
+                        // The notification threads did not complete in time so force them to stop
+                        List<Runnable> droppedNotifications = notifyPool.shutdownNow();
+                        int activeNotificationCount = 0;
+                        if (notifyPool instanceof ThreadPoolExecutor) {
+                            activeNotificationCount = ((ThreadPoolExecutor) notifyPool).getActiveCount();
+                        }
+                        int unstartedNotificationCount = droppedNotifications != null ? droppedNotifications.size() : 0;
+                        int droppedNotificationCount = unstartedNotificationCount + activeNotificationCount;
+                        config.logger.warn("Application terminated. " + droppedNotificationCount + " error(s) were not sent to Bugsnag");
+                    }
+                } catch (InterruptedException e) {
+                    config.logger.warn("Application terminated while waiting for errors to be sent to Bugsnag");
+                }
+            }
+        });
+    }
+
+    public void notifyAsync(Notification notification) {
+        notifyPool.execute(new AsynchronousNotification(config, notification));
+    }
+
+    public class AsynchronousNotification implements Runnable {
+        private Configuration config;
+        private Notification notification;
+
+        public AsynchronousNotification(Configuration config, Notification notification) {
+            this.config = config;
+            this.notification = notification;
+        }
+
+        public void run() {
+            notification.deliver();
+        }
+    }
+}

--- a/src/main/java/com/bugsnag/NotificationWorker.java
+++ b/src/main/java/com/bugsnag/NotificationWorker.java
@@ -53,15 +53,13 @@ public class NotificationWorker {
     }
 
     public void notifyAsync(Notification notification) {
-        notifyPool.execute(new AsynchronousNotification(config, notification));
+        notifyPool.execute(new AsynchronousNotification(notification));
     }
 
     public class AsynchronousNotification implements Runnable {
-        private Configuration config;
         private Notification notification;
 
-        public AsynchronousNotification(Configuration config, Notification notification) {
-            this.config = config;
+        public AsynchronousNotification(Notification notification) {
             this.notification = notification;
         }
 

--- a/src/main/java/com/bugsnag/NotificationWorker.java
+++ b/src/main/java/com/bugsnag/NotificationWorker.java
@@ -1,7 +1,11 @@
 package com.bugsnag;
 
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Handles notifications to Bugsnag using a thread pool to manage asynchronous notification


### PR DESCRIPTION
Adds a thread pool with 2 daemon worker threads that allow the notification to Bugsnag to occur asynchronously. Notifications are queued if the worker threads are busy.

Async notification is turned on by default but synchronous notification can be used using the `setAsynchronousNotification` method