### PR TITLE
[WIP] Bugsnag Logback appender

### DIFF
--- a/examples/logback/README.md
+++ b/examples/logback/README.md
@@ -1,0 +1,16 @@
+# Bugsnag Logback Java Example
+
+An example application to show how to use Bugsnag to report exceptions logged using
+[Logback](http://logback.qos.ch/).
+
+- Build the app
+
+    ```shell
+    ../../gradlew clean assemble
+    ```
+
+- Run the app
+
+    ```shell
+    ../../gradlew run
+    ```

--- a/examples/logback/build.gradle
+++ b/examples/logback/build.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'application'
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    compile 'org.slf4j:slf4j-api:1.7.21'
+    compile 'ch.qos.logback:logback-classic:1.1.7'
+    compile rootProject
+    compile project(':logback-appender')
+}
+
+mainClassName = "com.bugsnag.examples.logback.ExampleApp"

--- a/examples/logback/src/main/java/com/bugsnag/example/logback/ExampleApp.java
+++ b/examples/logback/src/main/java/com/bugsnag/example/logback/ExampleApp.java
@@ -1,0 +1,23 @@
+package com.bugsnag.example.logback;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExampleApp {
+    /**
+     * Example showing logs with exceptions which will get reported to Bugsnag.
+     */
+    public static void main(String[] args) {
+        Logger logger = LoggerFactory.getLogger(ExampleApp.class);
+
+        // Logs with Throwable will be send to Bugsnag
+        logger.warn("Warning will be reported to Bugsnag", new Throwable("Test warn"));
+        logger.error("Error will be reported to Bugsnag", new Throwable("Test error"));
+
+        // Logs without will not
+        logger.info("Not reported to Bugsnag");
+        logger.error("Also not reported to Bugsnag");
+
+        System.exit(0);
+    }
+}

--- a/examples/logback/src/main/java/com/bugsnag/example/logback/ExampleAppLogAppender.java
+++ b/examples/logback/src/main/java/com/bugsnag/example/logback/ExampleAppLogAppender.java
@@ -1,0 +1,14 @@
+package com.bugsnag.example.logback;
+
+import com.bugsnag.Bugsnag;
+import com.bugsnag.logback.BugsnagAppender;
+
+/**
+ * Example implementation of the abstract BugsnagAppender class.
+ */
+public class ExampleAppLogAppender extends BugsnagAppender {
+    @Override
+    protected Bugsnag initBugsnag() {
+        return new Bugsnag("YOUR-API-KEY");
+    }
+}

--- a/examples/logback/src/main/resources/logback.xml
+++ b/examples/logback/src/main/resources/logback.xml
@@ -1,0 +1,18 @@
+<configuration>
+
+    <!-- Set up console appender -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-4relative [%thread] %-5level %logger{35} - %msg %n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Set up Bugsnag appender -->
+    <appender name="BUGSNAG" class="com.bugsnag.example.logback.ExampleAppLogAppender" />
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="BUGSNAG" />
+    </root>
+
+</configuration>

--- a/logback-appender/build.gradle
+++ b/logback-appender/build.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'java'
+apply plugin: 'net.researchgate.release'
+
+sourceCompatibility = 1.6
+targetCompatibility = 1.6
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    compile 'ch.qos.logback:logback-classic:1.1.7'
+    compile rootProject
+}

--- a/logback-appender/build.gradle
+++ b/logback-appender/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'net.researchgate.release'
+apply plugin: 'maven'
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
@@ -11,4 +12,48 @@ repositories {
 dependencies {
     compile 'ch.qos.logback:logback-classic:1.1.7'
     compile rootProject
+}
+
+// Required to upload releases to Sonatype
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: sonatypeUsername, password: sonatypePassword)
+            }
+
+            pom.artifactId = 'bugsnag'
+            pom.groupId = 'com.bugsnag.logback-appender'
+
+            pom.project {
+                name 'bugsnag-logback-appender'
+                packaging 'jar'
+                description 'Official Bugsnag notifier for Java applications - Logback appender'
+                url 'http://bugsnag.com/'
+
+                scm {
+                    url 'https://github.com/bugsnag/bugsnag-java/logback-appender'
+                    connection 'scm:git:git@github.com:bugsnag/bugsnag-java.git'
+                    developerConnection 'scm:git:git@github.com:bugsnag/bugsnag-java.git'
+                }
+
+                licenses {
+                    license {
+                        name 'MIT'
+                        url 'http://opensource.org/licenses/MIT'
+                        distribution 'repo'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id 'james'
+                        name 'James Smith'
+                    }
+                }
+            }
+        }
+    }
 }

--- a/logback-appender/src/main/java/com/bugsnag/logback/BugsnagAppender.java
+++ b/logback-appender/src/main/java/com/bugsnag/logback/BugsnagAppender.java
@@ -1,0 +1,68 @@
+package com.bugsnag.logback;
+
+import com.bugsnag.Bugsnag;
+import com.bugsnag.Report;
+import com.bugsnag.Severity;
+import com.bugsnag.callbacks.Callback;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.classic.spi.ThrowableProxy;
+import ch.qos.logback.core.AppenderBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Bugsnag log appender that reports logs supplied with a Throwable to Bugsnag.
+ */
+public abstract class BugsnagAppender extends AppenderBase<LoggingEvent> {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(BugsnagAppender.class);
+    Bugsnag bugsnag;
+
+    protected BugsnagAppender() {
+        super();
+        bugsnag = initBugsnag();
+    }
+
+    /**
+     * Initialize the Bugsnag client to be used by the logging appender.
+     * @return the Bugsnag client.
+     */
+    protected abstract Bugsnag initBugsnag();
+
+    @Override
+    protected void append(LoggingEvent event) {
+        if (bugsnag == null) {
+            LOGGER.debug("Cannot notify Bugsnag - bugsnag is null");
+            return;
+        }
+
+        Throwable throwable;
+        Severity severity;
+        if (event.getLevel().levelInt <= Level.INFO.levelInt) {
+            severity = Severity.INFO;
+        } else if (event.getLevel().levelInt <= Level.WARN.levelInt) {
+            severity = Severity.WARNING;
+        } else {
+            severity = Severity.ERROR;
+        }
+
+        if (event.getThrowableProxy() != null) {
+            // Throwable provided
+            throwable = ((ThrowableProxy)event.getThrowableProxy()).getThrowable();
+
+            if (throwable == null) {
+                LOGGER.debug("Cannot notify Bugsnag - throwable is null");
+            } else {
+                final String logMessage = event.getMessage();
+                bugsnag.notify(throwable, severity, new Callback() {
+                    @Override
+                    public void beforeNotify(Report report) {
+                        report.addToTab("Log Message", "Message", logMessage);
+                    }
+                });
+            }
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,4 @@
-include ':examples:simple', ':examples:servlet'
+include ':examples:simple'
+include ':examples:servlet'
+include ':examples:logback'
+include 'logback-appender'


### PR DESCRIPTION
Adds a [Logback](http://logback.qos.ch/) appender to report logs containing Throwables to Bugsnag.

For example, this log call would result in a notification to Bugsnag:
`logger.error("Error will be reported to Bugsnag", new Throwable("Test error"));`

A separate module which would be added as a dependency to projects using Logback. Projects would be required to implement `BugsnagAppender.initBugsnag()` to return a `Bugsnag` to use for notifying.

TODO:
* [ ] Documentation
* [ ] Build configuration to produce a separate JAR