### PR TITLE
Add Spring example apps

### DIFF
--- a/examples/spring-web/README.md
+++ b/examples/spring-web/README.md
@@ -1,0 +1,13 @@
+# Bugsnag Spring web Java Example
+
+A Spring Boot example application to show how to use Bugsnag in a Spring web based Java application.
+
+- Start the web server
+
+    ```shell
+    ../../gradlew clean bootRun
+    ```
+
+- Cause a crash
+
+    http://localhost:8080/

--- a/examples/spring-web/build.gradle
+++ b/examples/spring-web/build.gradle
@@ -1,0 +1,23 @@
+apply plugin: 'spring-boot'
+
+buildscript {
+    ext {
+        springBootVersion = '1.4.1.RELEASE'
+    }
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
+    }
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    compile("org.springframework.boot:spring-boot-starter-web")
+
+    compile rootProject
+}

--- a/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Application.java
+++ b/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Application.java
@@ -1,0 +1,20 @@
+package com.bugsnag.example.spring.web;
+
+import org.apache.log4j.Logger;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Kicks off the Spring Boot application.
+ */
+@SpringBootApplication
+public class Application {
+
+    private static final Logger LOGGER = Logger.getLogger(Application.class);
+
+    public static void main(String[] args) throws Exception {
+        SpringApplication.run(Application.class, args);
+
+        LOGGER.info("Now visit http://localhost:8080 in your web browser");
+    }
+}

--- a/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/ApplicationRestController.java
+++ b/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/ApplicationRestController.java
@@ -1,0 +1,102 @@
+package com.bugsnag.example.spring.web;
+
+import com.bugsnag.Bugsnag;
+import com.bugsnag.Severity;
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ApplicationRestController {
+
+    private static final Logger LOGGER = Logger.getLogger(ApplicationRestController.class);
+
+    // Inject the bugsnag notifier bean defined in Config.java
+    @Autowired
+    private Bugsnag bugsnag;
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    private final String links =
+            "<a href=\"/send-handled-exception\">Send a handled exception to Bugsnag</a><br/>"
+            + "<a href=\"/send-handled-exception-info\">Send a handled exception to Bugsnag with INFO severity</a><br/>"
+            + "<a href=\"/send-handled-exception-with-metadata\">Send a handled exception to Bugsnag with custom MetaData</a><br/>"
+            + "<a href=\"/send-unhandled-exception\">Send an unhandled exception to Bugsnag</a><br/>"
+            + "<a href=\"/shutdown\">Shutdown the application</a><br/>";
+
+    @RequestMapping("/")
+    public String index() {
+        return links;
+    }
+
+    @RequestMapping("/send-handled-exception")
+    public String sendHandledException() {
+        LOGGER.info("Sending a handled exception to Bugsnag");
+        try {
+            throw new RuntimeException("Handled exception - default severity");
+        } catch (RuntimeException e) {
+            bugsnag.notify(e);
+        }
+
+        return links + "<br/>Sent a handled exception to Bugsnag";
+    }
+
+    @RequestMapping("/send-handled-exception-info")
+    public String sendHandledExceptionInfo() {
+        LOGGER.info("Sending a handled exception to Bugsnag with INFO severity");
+        try {
+            throw new RuntimeException("Handled exception - INFO severity");
+        } catch (RuntimeException e) {
+            bugsnag.notify(e, Severity.INFO);
+        }
+
+        return links + "<br/>Sent a handled exception to Bugsnag with INFO severity";
+    }
+
+    @RequestMapping("/send-handled-exception-with-metadata")
+    public String sendHandledExceptionWithMetadata() {
+        LOGGER.info("Sending a handled exception to Bugsnag with custom MetaData");
+        try {
+            throw new RuntimeException("Handled exception - custom metadata");
+        } catch (RuntimeException e) {
+            bugsnag.notify(e, (report) -> {
+                report.setSeverity(Severity.WARNING);
+                report.addToTab("report", "something", "that happened");
+                report.setContext("the context");
+            });
+        }
+
+        return links + "<br/>Sent a handled exception to Bugsnag with custom MetaData";
+    }
+
+    @RequestMapping("/send-unhandled-exception")
+    public String sendUnhandledException() throws InterruptedException {
+        // Test an unhanded exception from a different thread as shutdown hooks
+        // won't be called if executed from this thread
+        LOGGER.info("Sending an unhandled exception to Bugsnag");
+        Thread thread = new Thread() {
+            @Override
+            public void run() {
+                throw new RuntimeException("Unhandled exception");
+            }
+        };
+
+        thread.start();
+
+        // Wait for unhandled exception thread to finish
+        thread.join();
+
+        return links + "<br/>Sent an unhandled exception to Bugsnag";
+    }
+
+    @RequestMapping("/shutdown")
+    public void shutdown() throws InterruptedException {
+        LOGGER.info("Shutting down application");
+
+        SpringApplication.exit(applicationContext);
+    }
+}

--- a/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Config.java
+++ b/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Config.java
@@ -1,0 +1,38 @@
+package com.bugsnag.example.spring.web;
+
+import com.bugsnag.Bugsnag;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Date;
+
+@Configuration
+public class Config {
+
+    // Define singleton bean "bugsnag" which can be injected into any Spring managed class with @Autowired.
+    @Bean
+    public Bugsnag bugsnag() {
+        // Create a Bugsnag client
+        Bugsnag bugsnag = new Bugsnag("YOUR-API-KEY");
+
+        // Set some diagnostic data which will not change during the
+        // lifecycle of the application
+        bugsnag.setReleaseStage("staging");
+        bugsnag.setAppVersion("1.0.1");
+
+        // Create and attach a simple Bugsnag callback.
+        // Use Callbacks to send custom diagnostic data which changes during
+        // the lifecyle of your application
+        bugsnag.addCallback((report) -> {
+            report.addToTab("diagnostics", "timestamp", new Date());
+            report.addToTab("customer", "name", "acme-inc");
+            report.addToTab("customer", "paying", true);
+            report.addToTab("customer", "spent", 1234);
+            report.setUserName("User Name");
+            report.setUserEmail("user@example.com");
+            report.setUserId("12345");
+        });
+
+        return bugsnag;
+    }
+}

--- a/examples/spring-web/src/main/resources/application.properties
+++ b/examples/spring-web/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+logging.level.com.bugsnag=DEBUG

--- a/examples/spring/README.md
+++ b/examples/spring/README.md
@@ -1,0 +1,9 @@
+# Bugsnag Spring Java Example
+
+A Spring Boot example application to show how to use Bugsnag in a Spring based Java application.
+
+- Run the app
+
+    ```shell
+    ../../gradlew clean bootRun
+    ```

--- a/examples/spring/build.gradle
+++ b/examples/spring/build.gradle
@@ -1,0 +1,23 @@
+apply plugin: 'spring-boot'
+
+buildscript {
+    ext {
+        springBootVersion = '1.4.1.RELEASE'
+    }
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
+    }
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    compile("org.springframework.boot:spring-boot-starter")
+
+    compile rootProject
+}

--- a/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Application.java
+++ b/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Application.java
@@ -1,0 +1,15 @@
+package com.bugsnag.example.spring.cli;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Kicks off the Spring Boot application.
+ */
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) throws Exception {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/examples/spring/src/main/java/com/bugsnag/example/spring/cli/ApplicationCommandLineRunner.java
+++ b/examples/spring/src/main/java/com/bugsnag/example/spring/cli/ApplicationCommandLineRunner.java
@@ -1,34 +1,30 @@
-package com.bugsnag.example.simple;
+package com.bugsnag.example.spring.cli;
 
 import com.bugsnag.Bugsnag;
 import com.bugsnag.Severity;
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
 
-import java.util.Date;
+@Component
+public class ApplicationCommandLineRunner implements CommandLineRunner {
 
-public class ExampleApp {
-    public static void main(String[] args) throws InterruptedException {
-        // Create a Bugsnag client
-        Bugsnag bugsnag = new Bugsnag("YOUR-API-KEY");
+    private static final Logger LOGGER = Logger.getLogger(ApplicationCommandLineRunner.class);
 
-        // Set some diagnostic data which will not change during the
-        // lifecycle of the application
-        bugsnag.setReleaseStage("staging");
-        bugsnag.setAppVersion("1.0.1");
+    // Inject the bugsnag notifier bean defined in Config.java
+    @Autowired
+    private Bugsnag bugsnag;
 
-        // Create and attach a simple Bugsnag callback.
-        // Use Callbacks to send custom diagnostic data which changes during
-        // the lifecyle of your application
-        bugsnag.addCallback((report) -> {
-            report.addToTab("diagnostics", "timestamp", new Date());
-            report.addToTab("customer", "name", "acme-inc");
-            report.addToTab("customer", "paying", true);
-            report.addToTab("customer", "spent", 1234);
-            report.setUserName("User Name");
-            report.setUserEmail("user@example.com");
-            report.setUserId("12345");
-        });
+    @Autowired
+    private ApplicationContext applicationContext;
 
+    @Override
+    public void run(final String... args) throws Exception {
         // Send a handled exception to Bugsnag
+        LOGGER.info("Sending a handled exception to Bugsnag");
         try {
             throw new RuntimeException("Handled exception - default severity");
         } catch (RuntimeException e) {
@@ -36,6 +32,7 @@ public class ExampleApp {
         }
 
         // Send a handled exception to Bugsnag with info severity
+        LOGGER.info("Sending a handled exception to Bugsnag with INFO severity");
         try {
             throw new RuntimeException("Handled exception - INFO severity");
         } catch (RuntimeException e) {
@@ -43,6 +40,7 @@ public class ExampleApp {
         }
 
         // Send a handled exception with custom MetaData
+        LOGGER.info("Sending a handled exception to Bugsnag with custom MetaData");
         try {
             throw new RuntimeException("Handled exception - custom metadata");
         } catch (RuntimeException e) {
@@ -55,6 +53,7 @@ public class ExampleApp {
 
         // Test an unhanded exception from a different thread as shutdown hooks
         // won't be called if executed from this thread
+        LOGGER.info("Sending an unhandled exception to Bugsnag");
         Thread thread = new Thread() {
             @Override
             public void run() {
@@ -66,5 +65,8 @@ public class ExampleApp {
 
         // Wait for unhandled exception thread to finish before exiting
         thread.join();
+
+        // Exit the spring application
+        SpringApplication.exit(applicationContext);
     }
 }

--- a/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Config.java
+++ b/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Config.java
@@ -1,0 +1,38 @@
+package com.bugsnag.example.spring.cli;
+
+import com.bugsnag.Bugsnag;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Date;
+
+@Configuration
+public class Config {
+
+    // Define singleton bean "bugsnag" which can be injected into any Spring managed class with @Autowired.
+    @Bean
+    public Bugsnag bugsnag() {
+        // Create a Bugsnag client
+        Bugsnag bugsnag = new Bugsnag("YOUR-API-KEY");
+
+        // Set some diagnostic data which will not change during the
+        // lifecycle of the application
+        bugsnag.setReleaseStage("staging");
+        bugsnag.setAppVersion("1.0.1");
+
+        // Create and attach a simple Bugsnag callback.
+        // Use Callbacks to send custom diagnostic data which changes during
+        // the lifecyle of your application
+        bugsnag.addCallback((report) -> {
+            report.addToTab("diagnostics", "timestamp", new Date());
+            report.addToTab("customer", "name", "acme-inc");
+            report.addToTab("customer", "paying", true);
+            report.addToTab("customer", "spent", 1234);
+            report.setUserName("User Name");
+            report.setUserEmail("user@example.com");
+            report.setUserId("12345");
+        });
+
+        return bugsnag;
+    }
+}

--- a/examples/spring/src/main/resources/application.properties
+++ b/examples/spring/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+logging.level.com.bugsnag=DEBUG

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':examples:simple', ':examples:servlet'
+include ':examples:simple', ':examples:servlet', ':examples:spring', ':examples:spring-web'

--- a/src/main/java/com/bugsnag/Bugsnag.java
+++ b/src/main/java/com/bugsnag/Bugsnag.java
@@ -372,4 +372,13 @@ public class Bugsnag {
 
         return true;
     }
+
+    /**
+     * Close the connection to Bugsnag and unlink the exception handler.
+     */
+    public void close() {
+        LOGGER.debug("Closing connection to Bugsnag");
+        config.delivery.close();
+        ExceptionHandler.disable(this);
+    }
 }

--- a/src/main/java/com/bugsnag/delivery/AsyncHttpDelivery.java
+++ b/src/main/java/com/bugsnag/delivery/AsyncHttpDelivery.java
@@ -73,6 +73,11 @@ public class AsyncHttpDelivery implements HttpDelivery {
         });
     }
 
+    @Override
+    public void close() {
+        shutdown();
+    }
+
     private void shutdown() {
         shuttingDown = true;
         executorService.shutdown();

--- a/src/main/java/com/bugsnag/delivery/Delivery.java
+++ b/src/main/java/com/bugsnag/delivery/Delivery.java
@@ -10,4 +10,9 @@ public interface Delivery {
      * @param object     the object to deliver.
      */
     void deliver(Serializer serializer, Object object);
+
+    /**
+     * Close any open connections to Bugsnag.
+     */
+    void close();
 }

--- a/src/main/java/com/bugsnag/delivery/OutputStreamDelivery.java
+++ b/src/main/java/com/bugsnag/delivery/OutputStreamDelivery.java
@@ -24,4 +24,9 @@ public class OutputStreamDelivery implements Delivery {
             logger.warn("Error not reported to Bugsnag - exception when serializing payload", ex);
         }
     }
+
+    @Override
+    public void close() {
+        // Nothing to do here.
+    }
 }

--- a/src/main/java/com/bugsnag/delivery/SyncHttpDelivery.java
+++ b/src/main/java/com/bugsnag/delivery/SyncHttpDelivery.java
@@ -81,4 +81,9 @@ public class SyncHttpDelivery implements HttpDelivery {
             connection.disconnect();
         }
     }
+
+    @Override
+    public void close() {
+        // Nothing to do here.
+    }
 }

--- a/src/test/java/com/bugsnag/BugsnagTest.java
+++ b/src/test/java/com/bugsnag/BugsnagTest.java
@@ -35,6 +35,10 @@ public class BugsnagTest {
             @Override
             public void deliver(Serializer serializer, Object object) {
             }
+
+            @Override
+            public void close() {
+            }
         });
 
         // Ignore neither
@@ -59,6 +63,10 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object) {
+            }
+
+            @Override
+            public void close() {
             }
         });
         bugsnag.setReleaseStage("production");
@@ -89,6 +97,10 @@ public class BugsnagTest {
                 Report report = ((Notification) object).getEvents().get(0);
                 assertTrue(report.getExceptions().get(0).getStacktrace().get(0).isInProject());
             }
+
+            @Override
+            public void close() {
+            }
         });
         bugsnag.setProjectPackages("com.bugsnag");
 
@@ -105,6 +117,10 @@ public class BugsnagTest {
                 Report report = ((Notification) object).getEvents().get(0);
                 assertEquals("1.2.3", report.getApp().get("version"));
             }
+
+            @Override
+            public void close() {
+            }
         });
         assertTrue(bugsnag.notify(new Throwable()));
     }
@@ -119,6 +135,10 @@ public class BugsnagTest {
                 Report report = ((Notification) object).getEvents().get(0);
                 assertEquals("testtype", report.getApp().get("type"));
             }
+
+            @Override
+            public void close() {
+            }
         });
         assertTrue(bugsnag.notify(new Throwable()));
     }
@@ -131,6 +151,10 @@ public class BugsnagTest {
             public void deliver(Serializer serializer, Object object) {
                 Report report = ((Notification) object).getEvents().get(0);
                 assertEquals(Severity.INFO.getValue(), report.getSeverity());
+            }
+
+            @Override
+            public void close() {
             }
         });
         assertTrue(bugsnag.notify(new Throwable(), Severity.INFO));
@@ -150,6 +174,10 @@ public class BugsnagTest {
                 assertEquals("[FILTERED]", firstTab.get("testfilter2"));
                 assertEquals("secretpassword", firstTab.get("testfilter3"));
                 assertEquals("[FILTERED]", secondTab.get("testfilter1"));
+            }
+
+            @Override
+            public void close() {
             }
         });
         assertTrue(bugsnag.notify(new Throwable(), new Callback() {
@@ -173,6 +201,10 @@ public class BugsnagTest {
                 assertEquals("123", report.getUser().get("id"));
                 assertEquals("test@example.com", report.getUser().get("email"));
                 assertEquals("test name", report.getUser().get("name"));
+            }
+
+            @Override
+            public void close() {
             }
         });
         assertTrue(bugsnag.notify(new Throwable(), new Callback() {
@@ -198,6 +230,10 @@ public class BugsnagTest {
                 Report report = ((Notification) object).getEvents().get(0);
                 assertEquals("the context", report.getContext());
             }
+
+            @Override
+            public void close() {
+            }
         });
         assertTrue(bugsnag.notify(new Throwable()));
     }
@@ -216,6 +252,10 @@ public class BugsnagTest {
             public void deliver(Serializer serializer, Object object) {
                 Report report = ((Notification) object).getEvents().get(0);
                 assertEquals("the grouping hash", report.getGroupingHash());
+            }
+
+            @Override
+            public void close() {
             }
         });
         assertTrue(bugsnag.notify(new Throwable()));
@@ -236,6 +276,10 @@ public class BugsnagTest {
                 Report report = ((Notification) object).getEvents().get(0);
                 assertEquals("newapikey", report.getApiKey());
             }
+
+            @Override
+            public void close() {
+            }
         });
         assertTrue(bugsnag.notify(new Throwable()));
     }
@@ -248,6 +292,10 @@ public class BugsnagTest {
             public void deliver(Serializer serializer, Object object) {
                 Report report = ((Notification) object).getEvents().get(0);
                 assertEquals("newapikey", report.getApiKey());
+            }
+
+            @Override
+            public void close() {
             }
         });
 
@@ -279,6 +327,10 @@ public class BugsnagTest {
             public void deliver(Serializer serializer, Object object) {
                 Report report = ((Notification) object).getEvents().get(0);
                 assertEquals("secondnewapikey", report.getApiKey());
+            }
+
+            @Override
+            public void close() {
             }
         });
         assertTrue(bugsnag.notify(new Throwable()));
@@ -320,6 +372,10 @@ public class BugsnagTest {
             public void deliver(Serializer serializer, Object object) {
                 assertEquals("https://www.example.com", endpoint);
             }
+
+            @Override
+            public void close() {
+            }
         });
         bugsnag.setEndpoint("https://www.example.com");
 
@@ -349,6 +405,10 @@ public class BugsnagTest {
             public void deliver(Serializer serializer, Object object) {
                 assertEquals("/127.0.0.1:8080", proxy.address().toString());
             }
+
+            @Override
+            public void close() {
+            }
         });
         Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("127.0.0.1", 8080));
         bugsnag.setProxy(proxy);
@@ -366,6 +426,10 @@ public class BugsnagTest {
                 Report report = ((Notification) object).getEvents().get(0);
                 // There is information about at least one thread
                 assertTrue(report.getThreads().size() > 0);
+            }
+
+            @Override
+            public void close() {
             }
         });
         assertTrue(bugsnag.notify(new Throwable()));


### PR DESCRIPTION
- Add Spring boot example app.
- Add Spring boot web based example app.
- Add `close` method to Bugsnag to ensure it tears down connections (this is automatically called by Spring when tearing down the bean).
- Change the simple example to use `close` rather than `Shutdown`.