### PR TITLE
Stop AsyncHttpDelivery from indefinitely blocking exit

### DIFF
--- a/examples/simple/src/main/java/com/bugsnag/example/simple/ExampleApp.java
+++ b/examples/simple/src/main/java/com/bugsnag/example/simple/ExampleApp.java
@@ -61,8 +61,5 @@ public class ExampleApp {
                 throw new RuntimeException("Unhandled exception");
             }
         }).start();
-
-        // Exit to run the shutdown hooks
-        System.exit(0);
     }
 }

--- a/src/main/java/com/bugsnag/delivery/AsyncHttpDelivery.java
+++ b/src/main/java/com/bugsnag/delivery/AsyncHttpDelivery.java
@@ -7,15 +7,23 @@ import org.slf4j.LoggerFactory;
 
 import java.net.Proxy;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 public class AsyncHttpDelivery implements HttpDelivery {
     private static final Logger logger = LoggerFactory.getLogger(AsyncHttpDelivery.class);
     private static final int SHUTDOWN_TIMEOUT = 5000;
 
-    protected HttpDelivery baseDelivery = new SyncHttpDelivery();
-    protected ExecutorService executorService = Executors.newSingleThreadExecutor();
+    private HttpDelivery baseDelivery = new SyncHttpDelivery();
+
+    // Create an exector service which keeps idle threads alive for a maximum of SHUTDOWN_TIMEOUT.
+    // This should avoid blocking an application that doesn't call shutdown from exiting.
+    private ExecutorService executorService =
+            new ThreadPoolExecutor(0, 1,
+                    SHUTDOWN_TIMEOUT, TimeUnit.MILLISECONDS,
+                    new LinkedBlockingQueue<Runnable>());
+
     private boolean shuttingDown = false;
 
     /**


### PR DESCRIPTION
The executor used by AsyncHttpDelivery indefinitely blocks application exit unless a shutdown is manually triggered. This replaces the executor with one which times out when idle and so doesn't block an exit.

cc @bullmo 