### PR TITLE
Use deprecated method to ensure we don't break with older versions of jackson

### DIFF
--- a/src/main/java/com/bugsnag/serialization/Serializer.java
+++ b/src/main/java/com/bugsnag/serialization/Serializer.java
@@ -13,7 +13,8 @@ public class Serializer {
     /**
      * Constructor.
      */
-    @SuppressWarnings("deprecation") // Use deprecated method to ensure we don't break with older versions of jackson
+    // Use deprecated method to ensure we don't break with older versions of jackson
+    @SuppressWarnings("deprecation")
     public Serializer() {
         mapper
             .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)

--- a/src/main/java/com/bugsnag/serialization/Serializer.java
+++ b/src/main/java/com/bugsnag/serialization/Serializer.java
@@ -13,10 +13,11 @@ public class Serializer {
     /**
      * Constructor.
      */
+    @SuppressWarnings("deprecation") // Use deprecated method to ensure we don't break with older versions of jackson
     public Serializer() {
         mapper
             .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
-            .setVisibility(
+            .setVisibilityChecker(
                 mapper.getVisibilityChecker().with(JsonAutoDetect.Visibility.NONE));
     }
 


### PR DESCRIPTION
Due to the horrors of Java dependency management, if you are using a version of jackson-databind pre 2.6, you will get `NoSuchMethodError`s in Bugsnag due to a method being renamed. If we use the deprecated method rather than the newly renamed one we can support both old and new versions of Jackson.