### PR TITLE
fix: Restore JDK7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,16 @@ jobs:
   - stage: test
     jdk: openjdk8
     script: ./gradlew check :test
-  # - stage: test                # Disabled due to SSL errors on Travis
-  #   jdk: openjdk7              # when downloading gradle
-  #   script: ./gradlew :test
   - stage: test
     jdk: oraclejdk9
     script: ./gradlew check :test
   - stage: test
     jdk: oraclejdk8
     script: ./gradlew check :test
+  - stage: test
+    jdk: openjdk7
+    script: ./gradlew :test
+    before_install: # Work around missing crypto in openjdk7
+    - sudo wget "https://bouncycastle.org/download/bcprov-ext-jdk15on-158.jar" -O "${JAVA_HOME}/jre/lib/ext/bcprov-ext-jdk15on-158.jar"
+    - sudo perl -pi.bak -e 's/^(security\.provider\.)([0-9]+)/$1.($2+1)/ge' /etc/java-7-openjdk/security/java.security
+    - echo "security.provider.1=org.bouncycastle.jce.provider.BouncyCastleProvider" | sudo tee -a /etc/java-7-openjdk/security/java.security

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 
 dependencies {
     compile 'com.fasterxml.jackson.core:jackson-databind:2.9.1'
-    compile 'com.google.guava:guava:23.1-jre'
+    compile 'com.google.guava:guava:23.1-android'
     compile 'org.slf4j:slf4j-api:1.7.25'
     compileOnly 'javax.servlet:javax.servlet-api:3.1.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'checkstyle'
 buildscript {
     repositories {

--- a/release.gradle
+++ b/release.gradle
@@ -52,7 +52,7 @@ modifyPom {
 publishing {
     publications {
         Publication(MavenPublication) {
-            artifact jar
+            from components.java
             groupId 'com.bugsnag'
             artifactId 'bugsnag'
             version project.version


### PR DESCRIPTION
* Replace missing SunEC in openJDK7 builds (works around https://github.com/gradle/gradle/issues/2421, fixes CI)
* Use android flavor of guava for JDK7 support (fixes class loading)

Fixes #65 