### PR TITLE
Cache hostname at launch

### DIFF
--- a/src/main/java/com/bugsnag/Configuration.java
+++ b/src/main/java/com/bugsnag/Configuration.java
@@ -34,6 +34,7 @@ public class Configuration {
         // Add built-in callbacks
         addCallback(new AppCallback(this));
         addCallback(new DeviceCallback());
+        DeviceCallback.initializeCache();
 
         if (ServletCallback.isAvailable()) {
             addCallback(new ServletCallback());

--- a/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
+++ b/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
@@ -35,6 +35,10 @@ public class DeviceCallback implements Callback {
             }
         });
 
+    public static void initializeCache() {
+        hostnameCache.get();
+    }
+
     @Override
     public void beforeNotify(Report report) {
         report

--- a/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
+++ b/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
@@ -2,42 +2,48 @@ package com.bugsnag.callbacks;
 
 import com.bugsnag.Report;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Locale;
 
 public class DeviceCallback implements Callback {
+    private static final Supplier<String> hostnameCache =
+        Suppliers.memoize(new Supplier<String>() {
+
+            public String get() {
+                // Windows always sets COMPUTERNAME
+                if (System.getProperty("os.name").startsWith("Windows")) {
+                    return System.getenv("COMPUTERNAME");
+                }
+
+                // Try the HOSTNAME env variable (most unix systems)
+                String hostname = System.getenv("HOSTNAME");
+                if (hostname != null) {
+                    return hostname;
+                }
+
+                // Resort to dns hostname lookup
+                try {
+                    return InetAddress.getLocalHost().getHostName();
+                } catch (UnknownHostException ex) {
+                    // Give up
+                }
+                return null;
+            }
+        });
+
     @Override
     public void beforeNotify(Report report) {
         report
-                .setDeviceInfo("hostname", getHostname())
+                .setDeviceInfo("hostname", hostnameCache.get())
                 .setDeviceInfo("osName", System.getProperty("os.name"))
                 .setDeviceInfo("osVersion", System.getProperty("os.version"))
                 .setDeviceInfo("osArch", System.getProperty("os.arch"))
                 .setDeviceInfo("runtimeName", System.getProperty("java.runtime.name"))
                 .setDeviceInfo("runtimeVersion", System.getProperty("java.runtime.version"))
                 .setDeviceInfo("locale", Locale.getDefault());
-    }
-
-    private String getHostname() {
-        // Windows always sets COMPUTERNAME
-        if (System.getProperty("os.name").startsWith("Windows")) {
-            return System.getenv("COMPUTERNAME");
-        }
-
-        // Try the HOSTNAME env variable (most unix systems)
-        String hostname = System.getenv("HOSTNAME");
-        if (hostname != null) {
-            return hostname;
-        }
-
-        // Resort to dns hostname lookup
-        try {
-            return InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException ex) {
-            // Give up
-        }
-
-        return null;
     }
 }


### PR DESCRIPTION
Caches device metadata during initialization to avoid spawning hella threads.

To reproduce:

* Launch example spring app
* `curl http://localhost:8080/send-unhandled-exception` maybe 300 times :D 
* Observe the number of threads (in a profiler or otherwise)