### PR TITLE
Make preemptive copy of map filtering specified keys

### DIFF
--- a/src/main/java/com/bugsnag/util/FilteredMap.java
+++ b/src/main/java/com/bugsnag/util/FilteredMap.java
@@ -1,99 +1,102 @@
 package com.bugsnag.util;
 
-
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
 /**
- * Decorates a map, and alters the return value of {@link #get(Object)} if the key matches a filter.
+ * Decorates a map by replacing values of filtered keys.
  */
 public class FilteredMap implements Map<String, Object> {
 
     private static final String FILTERED_PLACEHOLDER = "[FILTERED]";
 
-    private final Map<String, Object> map;
+    private final Map<String, Object> filteredCopy;
     private final Collection<String> keyFilters = new ArrayList<String>();
 
     public FilteredMap(Map<String, Object> map, Collection<String> keyFilters) {
-        this.map = map;
         this.keyFilters.addAll(keyFilters);
+        this.filteredCopy = createCopy(map);
+    }
+
+    private Map<String, Object> createCopy(Map<? extends String, ?> map) {
+        Map<String, Object> copy = new HashMap<String, Object>();
+        for (Entry<? extends String, ?> entry : map.entrySet()) {
+            if (entry.getValue() == null) {
+                copy.put(entry.getKey(), entry.getValue());
+            } else {
+                Object transformedValue = transformEntry(entry.getKey(), entry.getValue());
+                copy.put(entry.getKey(), transformedValue);
+            }
+        }
+        return copy;
     }
 
     @Override
     public int size() {
-        return map.size();
+        return filteredCopy.size();
     }
 
     @Override
     public boolean isEmpty() {
-        return map.isEmpty();
+        return filteredCopy.isEmpty();
     }
 
     @Override
     public boolean containsKey(Object key) {
-        return map.containsKey(key);
+        return filteredCopy.containsKey(key);
     }
 
     @Override
     public boolean containsValue(Object value) {
-        return values().contains(value);
+        return filteredCopy.containsValue(value);
     }
 
     @Override
     public Object get(Object key) {
-        Object obj = map.get(key);
-        return obj != null ? transformEntry(key, obj) : null;
+        return filteredCopy.get(key);
     }
 
     @Override
     public Object put(String key, Object value) {
-        return map.put(key, value);
+        if (value == null) {
+            return filteredCopy.put(key, null);
+        }
+        Object transformedValue = transformEntry(key, value);
+        return filteredCopy.put(key, transformedValue);
     }
 
     @Override
     public Object remove(Object key) {
-        return map.remove(key);
+        return filteredCopy.remove(key);
     }
 
     @Override
     public void putAll(Map<? extends String, ?> mapValues) {
-        map.putAll(mapValues);
+        Map<String, Object> copy = createCopy(mapValues);
+        filteredCopy.putAll(copy);
     }
 
     @Override
     public void clear() {
-        map.clear();
+        filteredCopy.clear();
     }
 
     @Override
     public Set<String> keySet() {
-        return map.keySet();
+        return filteredCopy.keySet();
     }
 
     @Override
     public Collection<Object> values() {
-        Collection<Object> objects = new ArrayList<Object>();
-
-        for (Entry<String, Object> entry : entrySet()) {
-            objects.add(entry.getValue());
-        }
-        return objects;
+        return filteredCopy.values();
     }
 
     @Override
     public Set<Entry<String, Object>> entrySet() {
-        Set<Entry<String, Object>> entries = map.entrySet();
-        Set<Entry<String, Object>> copy = new HashSet<Entry<String, Object>>();
-        copy.addAll(entries);
-
-        for (Entry<String, Object> entry : copy) {
-            String key = entry.getKey();
-            entry.setValue(transformEntry(key, entry.getValue()));
-        }
-        return copy;
+        return filteredCopy.entrySet();
     }
 
     private Object transformEntry(Object key, Object value) {
@@ -116,5 +119,4 @@ public class FilteredMap implements Map<String, Object> {
         }
         return false;
     }
-
 }

--- a/src/test/java/com/bugsnag/util/FilteredMapTest.java
+++ b/src/test/java/com/bugsnag/util/FilteredMapTest.java
@@ -18,6 +18,7 @@ public class FilteredMapTest {
     private static final String KEY_UNFILTERED = "unfiltered";
     private static final String KEY_FILTERED = "auth";
     private static final String KEY_NESTED = "nested";
+    private static final String KEY_UNMODIFIABLE = "unmodifiable";
     private static final String VAL_UNFILTERED = "Foo";
     private static final String VAL_FILTERED = "Bar";
     private static final String PLACEHOLDER_FILTERED = "[FILTERED]";
@@ -39,12 +40,14 @@ public class FilteredMapTest {
         nestedMap.put(KEY_FILTERED, VAL_FILTERED);
         map.put(KEY_NESTED, nestedMap);
 
+        map.put(KEY_UNMODIFIABLE, Collections.unmodifiableMap(nestedMap));
+
         this.filteredMap = new FilteredMap(map, Collections.singleton(KEY_FILTERED));
     }
 
     @Test
     public void testSize() {
-        assertEquals(3, filteredMap.size());
+        assertEquals(4, filteredMap.size());
     }
 
     @Test
@@ -57,7 +60,7 @@ public class FilteredMapTest {
 
     @Test
     public void testClear() throws Exception {
-        assertEquals(3, filteredMap.size());
+        assertEquals(4, filteredMap.size());
         filteredMap.clear();
         assertTrue(filteredMap.isEmpty());
     }
@@ -104,7 +107,7 @@ public class FilteredMapTest {
     @Test
     public void testKeySet() throws Exception {
         Set<String> keySet = filteredMap.keySet();
-        assertEquals(3, keySet.size());
+        assertEquals(4, keySet.size());
         assertTrue(keySet.contains(KEY_FILTERED));
         assertTrue(keySet.contains(KEY_UNFILTERED));
         assertTrue(keySet.contains(KEY_NESTED));
@@ -113,7 +116,7 @@ public class FilteredMapTest {
     @Test
     public void testValues() throws Exception {
         Collection<Object> values = filteredMap.values();
-        assertEquals(3, values.size());
+        assertEquals(4, values.size());
         assertTrue(values.contains(VAL_UNFILTERED));
         assertTrue(values.contains(PLACEHOLDER_FILTERED));
 
@@ -133,7 +136,7 @@ public class FilteredMapTest {
     @Test
     public void testEntrySet() throws Exception {
         Set<Map.Entry<String, Object>> entries = filteredMap.entrySet();
-        assertEquals(3, entries.size());
+        assertEquals(4, entries.size());
 
         int expectedCount = 0;
 
@@ -152,9 +155,13 @@ public class FilteredMapTest {
                 expectedCount++;
                 Object value = entry.getValue();
                 assertTrue(value instanceof FilteredMap);
+            } else if (key.equals(KEY_UNMODIFIABLE)) {
+                expectedCount++;
+                Map<String, Object> nested = (Map<String, Object>) entry.getValue();
+                assertEquals(2, nested.entrySet().size());
             }
         }
-        assertEquals(3, expectedCount);
+        assertEquals(4, expectedCount);
     }
 
 }


### PR DESCRIPTION
After upgrading to version 3.1.5, we noticed the following error:
```
com.bugsnag.delivery.SyncHttpDelivery    : Error not reported to Bugsnag - exception when serializing payload
com.bugsnag.serialization.SerializationException: Exception during serialization
    at com.bugsnag.serialization.Serializer.writeToStream(Serializer.java:36) ~[bugsnag-3.1.5.jar:na]
    at com.bugsnag.delivery.SyncHttpDelivery.deliver(SyncHttpDelivery.java:57) ~[bugsnag-3.1.5.jar:na]
    at com.bugsnag.delivery.AsyncHttpDelivery$2.run(AsyncHttpDelivery.java:71) [bugsnag-3.1.5.jar:na]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_162]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_162]
    at java.lang.Thread.run(Thread.java:748) [na:1.8.0_162]
Caused by: com.fasterxml.jackson.databind.JsonMappingException: (was java.lang.UnsupportedOperationException) (through reference chain: com.bugsnag.Notification["events"]->java.util.Collections$SingletonList[0]->com.bugsnag.Report["metaData"]->com.bugsnag.util.FilteredMap["request"]->com.bugsnag.util.FilteredMap["params"])
    at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:388) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:348) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.std.StdSerializer.wrapAndThrow(StdSerializer.java:343) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.std.MapSerializer.serializeFields(MapSerializer.java:637) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.std.MapSerializer.serialize(MapSerializer.java:536) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.std.MapSerializer.serialize(MapSerializer.java:30) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.std.MapSerializer.serializeFields(MapSerializer.java:633) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.std.MapSerializer.serialize(MapSerializer.java:536) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.std.MapSerializer.serialize(MapSerializer.java:30) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:704) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:689) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:155) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serializeContents(IndexedListSerializer.java:119) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serialize(IndexedListSerializer.java:79) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serialize(IndexedListSerializer.java:18) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:704) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:689) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:155) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:292) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ObjectMapper._configAndWriteValue(ObjectMapper.java:3697) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ObjectMapper.writeValue(ObjectMapper.java:3030) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.bugsnag.serialization.Serializer.writeToStream(Serializer.java:34) ~[bugsnag-3.1.5.jar:na]
    ... 5 common frames omitted
Caused by: java.lang.UnsupportedOperationException: null
    at java.util.Collections$UnmodifiableMap$UnmodifiableEntrySet$UnmodifiableEntry.setValue(Collections.java:1749) ~[na:1.8.0_162]
    at com.bugsnag.util.FilteredMap.entrySet(FilteredMap.java:94) ~[bugsnag-3.1.5.jar:na]
    at com.fasterxml.jackson.databind.ser.std.MapSerializer.serializeFields(MapSerializer.java:600) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.std.MapSerializer.serialize(MapSerializer.java:536) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.std.MapSerializer.serialize(MapSerializer.java:30) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    at com.fasterxml.jackson.databind.ser.std.MapSerializer.serializeFields(MapSerializer.java:633) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
    ... 23 common frames omitted
```

We propose a different approach to implement `FilteredMap`, instead of doing the filtering in every `java.util.Map` method, we make a copy of the target `map` and delegate `java.util.Map` methods to it.