### PR TITLE
Add setter for overriding error class

### DIFF
--- a/src/main/java/com/bugsnag/Exception.java
+++ b/src/main/java/com/bugsnag/Exception.java
@@ -7,15 +7,17 @@ import java.util.List;
 class Exception {
     private Configuration config;
     private Throwable throwable;
+    private String errorClass;
 
     Exception(Configuration config, Throwable throwable) {
         this.config = config;
         this.throwable = throwable;
+        this.errorClass = throwable.getClass().getName();
     }
 
     @Expose
     public String getErrorClass() {
-        return throwable.getClass().getName();
+        return errorClass;
     }
 
     @Expose
@@ -26,5 +28,13 @@ class Exception {
     @Expose
     public List<Stackframe> getStacktrace() {
         return Stackframe.getStacktrace(config, throwable.getStackTrace());
+    }
+
+    public void setErrorClass(String errorClass) {
+        this.errorClass = errorClass;
+    }
+
+    public Throwable getThrowable() {
+        return throwable;
     }
 }

--- a/src/main/java/com/bugsnag/Report.java
+++ b/src/main/java/com/bugsnag/Report.java
@@ -15,7 +15,7 @@ public class Report {
     private Configuration config;
 
     private String apiKey;
-    private Throwable throwable;
+    private final Exception exception;
     private final HandledState handledState;
     private Severity severity;
     private String groupingHash;
@@ -35,7 +35,7 @@ public class Report {
 
     Report(Configuration config, Throwable throwable, HandledState handledState) {
         this.config = config;
-        this.throwable = throwable;
+        this.exception = new Exception(config, throwable);
         this.handledState = handledState;
         this.severity = handledState.getOriginalSeverity();
     }
@@ -53,8 +53,9 @@ public class Report {
     @Expose
     protected List<Exception> getExceptions() {
         List<Exception> exceptions = new ArrayList<Exception>();
+        exceptions.add(exception);
 
-        Throwable currentThrowable = throwable;
+        Throwable currentThrowable = exception.getThrowable().getCause();
         while (currentThrowable != null) {
             exceptions.add(new Exception(config, currentThrowable));
             currentThrowable = currentThrowable.getCause();
@@ -117,21 +118,30 @@ public class Report {
      * @return The {@linkplain Throwable exception} which triggered this error report.
      */
     public Throwable getException() {
-        return throwable;
+        return exception.getThrowable();
     }
 
     /**
      * @return the class name from the exception contained in this error report.
      */
     public String getExceptionName() {
-        return throwable.getClass().getName();
+        return exception.getErrorClass();
+    }
+
+    /**
+     * Sets the class name from the exception contained in this error report.
+     *
+     * @param exceptionName the error name
+     */
+    public void setExceptionName(String exceptionName) {
+        exception.setErrorClass(exceptionName);
     }
 
     /**
      * @return The message from the exception contained in this error report.
      */
     public String getExceptionMessage() {
-        return throwable.getLocalizedMessage();
+        return exception.getThrowable().getLocalizedMessage();
     }
 
     /**

--- a/src/test/java/com/bugsnag/ExceptionTest.java
+++ b/src/test/java/com/bugsnag/ExceptionTest.java
@@ -1,0 +1,87 @@
+package com.bugsnag;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.bugsnag.callbacks.Callback;
+import com.bugsnag.delivery.Delivery;
+import com.bugsnag.serialization.Serializer;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class ExceptionTest {
+
+    private Exception exception;
+    private RuntimeException ogThrowable;
+
+    /**
+     * Initialises a config
+     *
+     * @throws Throwable if config couldn't be initialised
+     */
+    @Before
+    public void setUp() throws Throwable {
+        Configuration config = new Configuration("api-key");
+        ogThrowable = new RuntimeException("Test");
+        exception = new Exception(config, ogThrowable);
+    }
+
+    @Test
+    public void testDefaults() throws Throwable {
+        assertEquals("java.lang.RuntimeException", exception.getErrorClass());
+        assertEquals("Test", exception.getMessage());
+        assertEquals(ogThrowable, exception.getThrowable());
+        assertFalse(exception.getStacktrace().isEmpty());
+    }
+
+    @Test
+    public void testClassOverride() throws Throwable {
+        exception.setErrorClass("Hello");
+        assertEquals("Hello", exception.getErrorClass());
+        assertEquals("Test", exception.getMessage());
+    }
+
+    @Test
+    public void testReportCallback() throws Throwable {
+        Bugsnag bugsnag = new Bugsnag("apikey");
+        bugsnag.setDelivery(new Delivery() {
+            @Override
+            public void deliver(Serializer serializer, Object object) {
+            }
+
+            @Override
+            public void close() {
+            }
+        });
+        assertTrue(bugsnag.notify(ogThrowable, new Callback() {
+            @Override
+            public void beforeNotify(Report report) {
+                try {
+                    assertEquals(ogThrowable, report.getException());
+                    assertEquals("Test", report.getExceptionMessage());
+                    assertEquals("java.lang.RuntimeException", report.getExceptionName());
+
+                    report.setExceptionName("Foo");
+                    assertEquals("Foo", report.getExceptionName());
+
+
+                    List<Exception> exceptions = report.getExceptions();
+                    assertEquals(1, exceptions.size());
+
+                    Exception exception = exceptions.get(0);
+                    assertNotNull(exception);
+                    assertEquals("Foo", exception.getErrorClass());
+                    assertEquals("Test", exception.getMessage());
+                } catch (Throwable throwable) {
+                    report.cancel();
+                }
+            }
+        }));
+    }
+
+}


### PR DESCRIPTION
Allows users to override the exception name by calling `report.setExceptionName()`

N.B. this is only supported for the top-level exception, and not any Throwable causes (as the top-level class is the important bit which shows in the dashboard).

Addresses #72 