### PR TITLE
Add coverage for serialisation of thread state properties

### DIFF
--- a/src/test/java/com/bugsnag/ThreadStateTest.java
+++ b/src/test/java/com/bugsnag/ThreadStateTest.java
@@ -1,17 +1,31 @@
 package com.bugsnag;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.Exception;
 import java.util.List;
 
 public class ThreadStateTest {
 
+    private List<ThreadState> threadStates;
+
+    /**
+     * Generates a list of current thread states
+     *
+     * @throws Exception if the thread state could not be constructed
+     */
+    @Before
+    public void setUp() throws Exception {
+        threadStates = ThreadState.getLiveThreads(new Configuration("apikey"));
+    }
+
     @Test
     public void testThreadStateDoesNotContainCurrentThread() {
-        List<ThreadState> threadStates = ThreadState.getLiveThreads(new Configuration("apikey"));
 
         for (ThreadState thread : threadStates) {
             if (thread.getId() == Thread.currentThread().getId()) {
@@ -21,5 +35,20 @@ public class ThreadStateTest {
 
         // Just test that there is at least one thread
         assertTrue(threadStates.size() > 1);
+    }
+
+    @Test
+    public void testThreadName() {
+        for (ThreadState threadState : threadStates) {
+            assertNotNull(threadState.getName());
+        }
+    }
+
+    @Test
+    public void testThreadStacktrace() {
+        for (ThreadState threadState : threadStates) {
+            List<Stackframe> stacktrace = threadState.getStacktrace();
+            assertNotNull(stacktrace);
+        }
     }
 }


### PR DESCRIPTION
Adds test coverage for serialisation of `ThreadState` name and stacktrace.