### PR TITLE
Session tracking on by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     compileOnly 'javax.servlet:javax.servlet-api:3.1.0'
 
     testCompile 'junit:junit:4.12'
-    testCompile 'org.slf4j:slf4j-jdk14:1.7.25'
+    testCompile 'org.slf4j:slf4j-simple:1.7.25'
     testCompile 'javax.servlet:javax.servlet-api:3.1.0'
     testCompile 'org.mockito:mockito-core:2.10.0'
 }

--- a/src/main/java/com/bugsnag/Bugsnag.java
+++ b/src/main/java/com/bugsnag/Bugsnag.java
@@ -181,7 +181,9 @@ public class Bugsnag {
      *
      * @param endpoint the endpoint to send reports to
      * @see #setDelivery
+     * @deprecated use {@link Configuration#setEndpoints(String, String)} instead
      */
+    @Deprecated
     public void setEndpoint(String endpoint) {
         if (config.delivery instanceof HttpDelivery) {
             ((HttpDelivery) config.delivery).setEndpoint(endpoint);

--- a/src/main/java/com/bugsnag/Bugsnag.java
+++ b/src/main/java/com/bugsnag/Bugsnag.java
@@ -507,7 +507,9 @@ public class Bugsnag {
      *
      * @param endpoint the endpoint to send reports to
      * @see #setDelivery
+     * @deprecated use {@link Configuration#setEndpoints(String, String)} instead
      */
+    @Deprecated
     public void setSessionEndpoint(String endpoint) {
         if (config.sessionDelivery instanceof HttpDelivery) {
             ((HttpDelivery) config.sessionDelivery).setEndpoint(endpoint);

--- a/src/main/java/com/bugsnag/Configuration.java
+++ b/src/main/java/com/bugsnag/Configuration.java
@@ -45,7 +45,7 @@ public class Configuration {
 
     Collection<Callback> callbacks = new ArrayList<Callback>();
     Serializer serializer = new Serializer();
-    private final AtomicBoolean autoCaptureSessions = new AtomicBoolean();
+    private final AtomicBoolean autoCaptureSessions = new AtomicBoolean(true);
 
     Configuration(String apiKey) {
         this.apiKey = apiKey;

--- a/src/main/java/com/bugsnag/Configuration.java
+++ b/src/main/java/com/bugsnag/Configuration.java
@@ -142,7 +142,7 @@ public class Configuration {
         }
 
         if (sessionDelivery instanceof HttpDelivery) {
-            // sessionEndpoint may be invalid (i.e. null) here, which should result in the default
+            // sessionEndpoint may be invalid (e.g. typo in the protocol) here, which should result in the default
             // HttpDelivery throwing a MalformedUrlException which prevents delivery.
             ((HttpDelivery) sessionDelivery).setEndpoint(sessionEndpoint);
         } else {

--- a/src/main/java/com/bugsnag/Configuration.java
+++ b/src/main/java/com/bugsnag/Configuration.java
@@ -120,7 +120,7 @@ public class Configuration {
      * @throws IllegalArgumentException if the notify endpoint is empty or null
      */
     public void setEndpoints(String notify, String sessions) throws IllegalArgumentException {
-        if (notify == null || notify.length() == 0) {
+        if (notify == null || notify.isEmpty()) {
             throw new IllegalArgumentException("Notify endpoint cannot be empty or null.");
         } else {
             if (delivery instanceof HttpDelivery) {
@@ -130,7 +130,7 @@ public class Configuration {
             }
         }
 
-        boolean invalidSessionsEndpoint = sessions == null || sessions.length() == 0;
+        boolean invalidSessionsEndpoint = sessions == null || sessions.isEmpty();
         String sessionEndpoint = null;
 
         if (invalidSessionsEndpoint) {

--- a/src/main/java/com/bugsnag/Configuration.java
+++ b/src/main/java/com/bugsnag/Configuration.java
@@ -142,7 +142,8 @@ public class Configuration {
         }
 
         if (sessionDelivery instanceof HttpDelivery) {
-            // sessionEndpoint may be invalid (e.g. typo in the protocol) here, which should result in the default
+            // sessionEndpoint may be invalid (e.g. typo in the protocol) here, which
+            // should result in the default
             // HttpDelivery throwing a MalformedUrlException which prevents delivery.
             ((HttpDelivery) sessionDelivery).setEndpoint(sessionEndpoint);
         } else {

--- a/src/main/java/com/bugsnag/Configuration.java
+++ b/src/main/java/com/bugsnag/Configuration.java
@@ -120,7 +120,7 @@ public class Configuration {
      * @throws IllegalArgumentException if the notify endpoint is empty or null
      */
     public void setEndpoints(String notify, String sessions) throws IllegalArgumentException {
-        if (notify == null || "".equals(notify)) {
+        if (notify == null || notify.length() == 0) {
             throw new IllegalArgumentException("Notify endpoint cannot be empty or null.");
         } else {
             if (delivery instanceof HttpDelivery) {
@@ -130,7 +130,7 @@ public class Configuration {
             }
         }
 
-        boolean invalidSessionsEndpoint = sessions == null || "".equals(sessions);
+        boolean invalidSessionsEndpoint = sessions == null || sessions.length() == 0;
         String sessionEndpoint = null;
 
         if (invalidSessionsEndpoint) {
@@ -142,6 +142,8 @@ public class Configuration {
         }
 
         if (sessionDelivery instanceof HttpDelivery) {
+            // sessionEndpoint may be invalid (i.e. null) here, which should result in the default
+            // HttpDelivery throwing a MalformedUrlException which prevents delivery.
             ((HttpDelivery) sessionDelivery).setEndpoint(sessionEndpoint);
         } else {
             LOGGER.warn("Delivery is not instance of HttpDelivery, cannot set sessions endpoint");

--- a/src/main/java/com/bugsnag/delivery/SyncHttpDelivery.java
+++ b/src/main/java/com/bugsnag/delivery/SyncHttpDelivery.java
@@ -44,6 +44,11 @@ public class SyncHttpDelivery implements HttpDelivery {
 
     @Override
     public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
+        if (endpoint == null) {
+            logger.warn("Endpoint configured incorrectly, skipping delivery.");
+            return;
+        }
+
         HttpURLConnection connection = null;
         try {
             URL url = new URL(endpoint);

--- a/src/main/java/com/bugsnag/delivery/SyncHttpDelivery.java
+++ b/src/main/java/com/bugsnag/delivery/SyncHttpDelivery.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
 import java.net.UnknownHostException;
@@ -81,6 +82,9 @@ public class SyncHttpDelivery implements HttpDelivery {
                 logger.warn(
                         "Error not reported to Bugsnag - got non-200 response code: {}", status);
             }
+        } catch (MalformedURLException ex) {
+            logger.warn("Error not reported to Bugsnag - malformed URL."
+                    + " Have you set both endpoints correctly?", ex);
         } catch (SerializationException ex) {
             logger.warn("Error not reported to Bugsnag - exception when serializing payload", ex);
         } catch (UnknownHostException ex) {

--- a/src/test/java/com/bugsnag/ConfigurationTest.java
+++ b/src/test/java/com/bugsnag/ConfigurationTest.java
@@ -3,20 +3,32 @@ package com.bugsnag;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.bugsnag.delivery.Delivery;
+import com.bugsnag.delivery.HttpDelivery;
+import com.bugsnag.serialization.Serializer;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import java.net.Proxy;
 import java.util.Map;
-
 
 public class ConfigurationTest {
 
     private Configuration config;
 
+    /**
+     * Creates a config object with fake delivery objects
+     *
+     * @throws Throwable if setup failed
+     */
     @Before
     public void setUp() throws Throwable {
         config = new Configuration("foo");
+        config.delivery = new FakeHttpDelivery();
+        config.sessionDelivery = new FakeHttpDelivery();
     }
 
     @Test
@@ -40,4 +52,77 @@ public class ConfigurationTest {
         assertNotNull(headers.get("Bugsnag-Payload-Version"));
     }
 
+    @Test
+    public void testEndpoints() {
+        String notify = "https://notify.myexample.com";
+        String sessions = "https://sessions.myexample.com";
+        config.setEndpoints(notify, sessions);
+
+        assertEquals(notify, getDeliveryEndpoint(config.delivery));
+        assertEquals(sessions, getDeliveryEndpoint(config.sessionDelivery));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullNotifyEndpoint() {
+        config.setEndpoints(null, "http://example.com");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptyNotifyEndpoint() {
+        config.setEndpoints("", "http://example.com");
+    }
+
+    @Test
+    public void testInvalidSessionEndpoint() {
+        config.setEndpoints("http://example.com", null);
+        assertFalse(config.shouldAutoCaptureSessions());
+        assertNull(getDeliveryEndpoint(config.sessionDelivery));
+
+        config.setEndpoints("http://example.com", "");
+        assertFalse(config.shouldAutoCaptureSessions());
+        assertNull(getDeliveryEndpoint(config.sessionDelivery));
+
+        config.setEndpoints("http://example.com", "http://sessions.example.com");
+        assertFalse(config.shouldAutoCaptureSessions());
+        assertEquals("http://sessions.example.com", getDeliveryEndpoint(config.sessionDelivery));
+    }
+
+    @Test
+    public void testAutoCaptureOverride() {
+        config.setAutoCaptureSessions(false);
+        config.setEndpoints("http://example.com", "http://example.com");
+        assertFalse(config.shouldAutoCaptureSessions());
+    }
+
+    private String getDeliveryEndpoint(Delivery delivery) {
+        if (delivery instanceof FakeHttpDelivery) {
+            return ((FakeHttpDelivery) delivery).endpoint;
+        }
+        return null;
+    }
+
+    static class FakeHttpDelivery implements HttpDelivery {
+        String endpoint;
+
+        @Override
+        public void setEndpoint(String endpoint) {
+            this.endpoint = endpoint;
+        }
+
+        @Override
+        public void setTimeout(int timeout) {
+        }
+
+        @Override
+        public void setProxy(Proxy proxy) {
+        }
+
+        @Override
+        public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
 }

--- a/src/test/java/com/bugsnag/ConfigurationTest.java
+++ b/src/test/java/com/bugsnag/ConfigurationTest.java
@@ -13,6 +13,8 @@ import com.bugsnag.serialization.Serializer;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.net.Proxy;
 import java.util.LinkedList;
 import java.util.Map;
@@ -91,6 +93,15 @@ public class ConfigurationTest {
     }
 
     @Test
+    public void testInvalidSessionWarningLogged() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(baos));
+        config.setEndpoints("http://example.com", "");
+        String logMsg = new String(baos.toByteArray());
+        assertTrue(logMsg.contains("The session tracking endpoint has not been set. Session tracking is disabled"));
+    }
+
+    @Test
     public void testAutoCaptureOverride() {
         config.setAutoCaptureSessions(false);
         config.setEndpoints("http://example.com", "http://example.com");
@@ -110,7 +121,15 @@ public class ConfigurationTest {
         };
         config.delivery = delivery;
         config.sessionDelivery = delivery;
+
+        // ensure log message
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(baos));
         config.setEndpoints("http://example.com", "http://sessions.example.com");
+        String logMsg = new String(baos.toByteArray());
+
+        assertTrue(logMsg.contains("Delivery is not instance of HttpDelivery, cannot set notify endpoint"));
+        assertTrue(logMsg.contains("Delivery is not instance of HttpDelivery, cannot set sessions endpoint"));
     }
 
     private String getDeliveryEndpoint(Delivery delivery) {

--- a/src/test/java/com/bugsnag/ConfigurationTest.java
+++ b/src/test/java/com/bugsnag/ConfigurationTest.java
@@ -98,7 +98,8 @@ public class ConfigurationTest {
         System.setErr(new PrintStream(baos));
         config.setEndpoints("http://example.com", "");
         String logMsg = new String(baos.toByteArray());
-        assertTrue(logMsg.contains("The session tracking endpoint has not been set. Session tracking is disabled"));
+        assertTrue(logMsg.contains("The session tracking endpoint "
+                + "has not been set. Session tracking is disabled"));
     }
 
     @Test
@@ -128,8 +129,10 @@ public class ConfigurationTest {
         config.setEndpoints("http://example.com", "http://sessions.example.com");
         String logMsg = new String(baos.toByteArray());
 
-        assertTrue(logMsg.contains("Delivery is not instance of HttpDelivery, cannot set notify endpoint"));
-        assertTrue(logMsg.contains("Delivery is not instance of HttpDelivery, cannot set sessions endpoint"));
+        assertTrue(logMsg.contains("Delivery is not instance of "
+                + "HttpDelivery, cannot set notify endpoint"));
+        assertTrue(logMsg.contains("Delivery is not instance of "
+                + "HttpDelivery, cannot set sessions endpoint"));
     }
 
     private String getDeliveryEndpoint(Delivery delivery) {

--- a/src/test/java/com/bugsnag/ConfigurationTest.java
+++ b/src/test/java/com/bugsnag/ConfigurationTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import com.bugsnag.delivery.Delivery;
 import com.bugsnag.delivery.HttpDelivery;
@@ -33,7 +34,7 @@ public class ConfigurationTest {
 
     @Test
     public void testDefaults() throws java.lang.Exception {
-        assertFalse(config.shouldAutoCaptureSessions());
+        assertTrue(config.shouldAutoCaptureSessions());
     }
 
     @Test

--- a/src/test/java/com/bugsnag/ConfigurationTest.java
+++ b/src/test/java/com/bugsnag/ConfigurationTest.java
@@ -14,7 +14,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.net.Proxy;
+import java.util.LinkedList;
 import java.util.Map;
+import java.util.Queue;
 
 public class ConfigurationTest {
 
@@ -104,6 +106,7 @@ public class ConfigurationTest {
 
     static class FakeHttpDelivery implements HttpDelivery {
         String endpoint;
+        Queue<Object> receivedObjects = new LinkedList<Object>();
 
         @Override
         public void setEndpoint(String endpoint) {
@@ -120,6 +123,7 @@ public class ConfigurationTest {
 
         @Override
         public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
+            receivedObjects.add(object);
         }
 
         @Override

--- a/src/test/java/com/bugsnag/ConfigurationTest.java
+++ b/src/test/java/com/bugsnag/ConfigurationTest.java
@@ -97,6 +97,22 @@ public class ConfigurationTest {
         assertFalse(config.shouldAutoCaptureSessions());
     }
 
+    @Test
+    public void testBaseDeliveryIgnoresEndpoint() {
+        Delivery delivery = new Delivery() {
+            @Override
+            public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        config.delivery = delivery;
+        config.sessionDelivery = delivery;
+        config.setEndpoints("http://example.com", "http://sessions.example.com");
+    }
+
     private String getDeliveryEndpoint(Delivery delivery) {
         if (delivery instanceof FakeHttpDelivery) {
             return ((FakeHttpDelivery) delivery).endpoint;

--- a/src/test/java/com/bugsnag/SessionTrackerTest.java
+++ b/src/test/java/com/bugsnag/SessionTrackerTest.java
@@ -46,13 +46,13 @@ public class SessionTrackerTest {
 
     @Test
     public void startAutoSessionDisabled() throws Throwable {
+        configuration.setAutoCaptureSessions(false);
         sessionTracker.startSession(new Date(), true);
         assertNull(sessionTracker.getSession());
     }
 
     @Test
     public void startAutoSessionEnabled() throws Throwable {
-        configuration.setAutoCaptureSessions(true);
         sessionTracker.startSession(new Date(), true);
         assertNotNull(sessionTracker.getSession());
     }

--- a/src/test/java/com/bugsnag/SessionTrackerTest.java
+++ b/src/test/java/com/bugsnag/SessionTrackerTest.java
@@ -14,6 +14,7 @@ import com.bugsnag.serialization.Serializer;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +26,7 @@ public class SessionTrackerTest {
 
     private SessionTracker sessionTracker;
     private Configuration configuration;
+    private ConfigurationTest.FakeHttpDelivery sessionDelivery;
 
     /**
      * Initialises config + session tracker
@@ -34,27 +36,72 @@ public class SessionTrackerTest {
     @Before
     public void setUp() throws Throwable {
         configuration = new Configuration("api-key");
+        sessionDelivery = new ConfigurationTest.FakeHttpDelivery();
+        configuration.sessionDelivery = sessionDelivery;
         sessionTracker = new SessionTracker(configuration);
         assertNull(sessionTracker.getSession());
     }
 
     @Test
-    public void startManualSession() throws Throwable {
+    public void startManualSessionAutoEnabled() throws Throwable {
         sessionTracker.startSession(new Date(), false);
         assertNotNull(sessionTracker.getSession());
     }
 
     @Test
-    public void startAutoSessionDisabled() throws Throwable {
+    public void startManualSessionAutoDisabled() throws Throwable {
+        configuration.setAutoCaptureSessions(false);
+        sessionTracker.startSession(new Date(), false);
+        assertNotNull(sessionTracker.getSession());
+    }
+
+    @Test
+    public void startAutoSessionAutoEnabled() throws Throwable {
+        sessionTracker.startSession(new Date(), true);
+        assertNotNull(sessionTracker.getSession());
+    }
+
+    @Test
+    public void startAutoSessionAutoDisabled() throws Throwable {
         configuration.setAutoCaptureSessions(false);
         sessionTracker.startSession(new Date(), true);
         assertNull(sessionTracker.getSession());
     }
 
     @Test
-    public void startAutoSessionEnabled() throws Throwable {
+    public void startSessionNoEndpoint() throws Throwable {
+        configuration.setEndpoints("http://example.com", null);
         sessionTracker.startSession(new Date(), true);
-        assertNotNull(sessionTracker.getSession());
+        assertNull(sessionTracker.getSession());
+    }
+
+    @Test
+    public void testMultiSessionsOneBatch() {
+        for (int k = 0; k < 100; k++) {
+            sessionTracker.startSession(new Date(k), false);
+        }
+        sessionTracker.flushSessions(new Date());
+        assertEquals(1, sessionDelivery.receivedObjects.size());
+        SessionPayload payload = (SessionPayload) sessionDelivery.receivedObjects.poll();
+
+        List<SessionCount> sessionCounts = (List<SessionCount>) payload.getSessionCounts();
+        assertEquals(1, sessionCounts.size());
+        assertEquals(100, sessionCounts.get(0).getSessionsStarted());
+    }
+
+    @Test
+    public void testMultiSessionsTwoBatches() {
+        for (int k = 0; k < 100; k++) {
+            sessionTracker.startSession(new Date(k * 1000), false);
+        }
+        sessionTracker.flushSessions(new Date());
+        assertEquals(1, sessionDelivery.receivedObjects.size());
+        SessionPayload payload = (SessionPayload) sessionDelivery.receivedObjects.poll();
+
+        List<SessionCount> sessionCounts = (List<SessionCount>) payload.getSessionCounts();
+        assertEquals(2, sessionCounts.size());
+        assertEquals(60, sessionCounts.get(0).getSessionsStarted());
+        assertEquals(40, sessionCounts.get(1).getSessionsStarted());
     }
 
     @Test


### PR DESCRIPTION
## Goal

Enables automatic session tracking by default.

## Changeset

### Added

`setEndpoints` API on configuration class.

### Removed

### Changed

- Auto capture enabled by default
- Deprecated `setEndpoint` and `setSessionEndpoint`

## Tests

Added and ran unit tests, as per the design spec.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
