### PR TITLE
refactor: fail build on compiler warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,3 +44,10 @@ test {
 checkstyle {
     toolVersion = "6.16"
 }
+
+gradle.projectsEvaluated {
+    tasks.withType(JavaCompile) {
+        // fail build on warnings, disable options complaining about Java 6 compatibility when building with JDK 7+
+        options.compilerArgs << "-Xlint:all" << "-Werror" << "-Xlint:-options"
+    }
+}

--- a/src/main/java/com/bugsnag/MetaData.java
+++ b/src/main/java/com/bugsnag/MetaData.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 class MetaData extends HashMap<String, Object> {
+    private static final long serialVersionUID = 2530038179702722770L;
+
     public void addToTab(String tabName, String key, Object value) {
         Map<String, Object> tab = getTab(tabName);
         tab.put(key, value);

--- a/src/main/java/com/bugsnag/Report.java
+++ b/src/main/java/com/bugsnag/Report.java
@@ -99,22 +99,22 @@ public class Report {
     }
 
     @Expose
-    public Map getApp() {
+    public Map<String, Object> getApp() {
         return diagnostics.app;
     }
 
     @Expose
-    public Map getDevice() {
+    public Map<String, Object> getDevice() {
         return diagnostics.device;
     }
 
     @Expose
-    public Map getUser() {
+    public Map<String, String> getUser() {
         return diagnostics.user;
     }
 
     @Expose
-    public Map getMetaData() {
+    public Map<String, Object> getMetaData() {
         return new FilteredMap(diagnostics.metaData, Arrays.asList(config.filters));
     }
 

--- a/src/main/java/com/bugsnag/callbacks/ServletCallback.java
+++ b/src/main/java/com/bugsnag/callbacks/ServletCallback.java
@@ -61,9 +61,9 @@ public class ServletCallback implements Callback {
 
     private Map<String, String> getHeaderMap(HttpServletRequest request) {
         Map<String, String> map = new HashMap<String, String>();
-        Enumeration headerNames = request.getHeaderNames();
+        Enumeration<String> headerNames = request.getHeaderNames();
         while (headerNames.hasMoreElements()) {
-            String key = (String) headerNames.nextElement();
+            String key = headerNames.nextElement();
             map.put(key, request.getHeader(key));
         }
 

--- a/src/main/java/com/bugsnag/serialization/SerializationException.java
+++ b/src/main/java/com/bugsnag/serialization/SerializationException.java
@@ -1,6 +1,8 @@
 package com.bugsnag.serialization;
 
 public class SerializationException extends Exception {
+    private static final long serialVersionUID = -6782171186575335048L;
+
     public SerializationException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/com/bugsnag/util/FilteredMap.java
+++ b/src/main/java/com/bugsnag/util/FilteredMap.java
@@ -99,9 +99,9 @@ public class FilteredMap implements Map<String, Object> {
         return filteredCopy.entrySet();
     }
 
+    @SuppressWarnings("unchecked")
     private Object transformEntry(Object key, Object value) {
         if (value instanceof Map) {
-            //noinspection unchecked
             return new FilteredMap((Map<String, Object>) value, keyFilters);
         }
         return shouldFilterKey((String) key) ? FILTERED_PLACEHOLDER : value;

--- a/src/test/java/com/bugsnag/BugsnagTest.java
+++ b/src/test/java/com/bugsnag/BugsnagTest.java
@@ -154,11 +154,14 @@ public class BugsnagTest {
         Bugsnag bugsnag = new Bugsnag("apikey");
         bugsnag.setFilters("testfilter1", "testfilter2");
         bugsnag.setDelivery(new Delivery() {
+            @SuppressWarnings("unchecked")
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
                 Report report = ((Notification) object).getEvents().get(0);
-                Map firstTab = (Map) report.getMetaData().get("firsttab");
-                final Map secondTab = (Map) report.getMetaData().get("secondtab");
+                Map<String, Object> firstTab =
+                        (Map<String, Object>) report.getMetaData().get("firsttab");
+                final Map<String, Object> secondTab =
+                        (Map<String, Object>) report.getMetaData().get("secondtab");
                 assertEquals("[FILTERED]", firstTab.get("testfilter1"));
                 assertEquals("[FILTERED]", firstTab.get("testfilter2"));
                 assertEquals("secretpassword", firstTab.get("testfilter3"));
@@ -339,6 +342,7 @@ public class BugsnagTest {
         assertFalse(bugsnag.notify(new Throwable()));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testEndpoint() {
         Bugsnag bugsnag = new Bugsnag("apikey");
@@ -454,6 +458,7 @@ public class BugsnagTest {
                 Map<String, Object> session = report.getSession();
                 assertNotNull(session);
 
+                @SuppressWarnings("unchecked")
                 Map<String, Object> handledCounts = (Map<String, Object>) session.get("events");
                 assertEquals(1, handledCounts.get("handled"));
                 assertEquals(0, handledCounts.get("unhandled"));
@@ -486,5 +491,6 @@ public class BugsnagTest {
 
     // Test exception class
     private class TestException extends RuntimeException {
+        private static final long serialVersionUID = -458298914160798211L;
     }
 }

--- a/src/test/java/com/bugsnag/ServletCallbackTest.java
+++ b/src/test/java/com/bugsnag/ServletCallbackTest.java
@@ -60,7 +60,7 @@ public class ServletCallbackTest {
         ServletCallback callback = new ServletCallback();
         callback.beforeNotify(report);
 
-        Map<String, Object> metadata = (Map<String, Object>)report.getMetaData();
+        Map<String, Object> metadata = report.getMetaData();
         assertTrue(metadata.containsKey("request"));
 
         Map<String, Object> request = (Map<String, Object>)metadata.get("request");

--- a/src/test/java/com/bugsnag/util/FilteredMapTest.java
+++ b/src/test/java/com/bugsnag/util/FilteredMapTest.java
@@ -99,6 +99,7 @@ public class FilteredMapTest {
         Object actual = filteredMap.get(KEY_NESTED);
         assertTrue(actual instanceof FilteredMap);
 
+        @SuppressWarnings("unchecked")
         Map<String, Object> nestedMap = (Map<String, Object>) actual;
         assertEquals(VAL_UNFILTERED, nestedMap.get(KEY_UNFILTERED));
         assertEquals(PLACEHOLDER_FILTERED, nestedMap.get(KEY_FILTERED));
@@ -125,6 +126,8 @@ public class FilteredMapTest {
 
         Object nestedObj = values.toArray(new Object[1])[0];
         assertTrue(nestedObj instanceof FilteredMap);
+
+        @SuppressWarnings("unchecked")
         Map<String, Object> nestedMap = (Map<String, Object>) nestedObj;
         values = nestedMap.values();
 
@@ -157,6 +160,8 @@ public class FilteredMapTest {
                 assertTrue(value instanceof FilteredMap);
             } else if (key.equals(KEY_UNMODIFIABLE)) {
                 expectedCount++;
+
+                @SuppressWarnings("unchecked")
                 Map<String, Object> nested = (Map<String, Object>) entry.getValue();
                 assertEquals(2, nested.entrySet().size());
             }


### PR DESCRIPTION
## Goal

Detect compiler warnings introduced in changes to Java code quickly.

## Changeset

- Updated gradle to error on any warnings found during compilation
- Address existing issues (raw types, missing `serialVersionUID`
- Suppress unchecked cast/deprecation warnings

## Tests

Ran tests on CI

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
