### PR TITLE
Capture trace of error reporting thread and identify with boolean flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.X.X (TBD)
+
+* Capture trace of error reporting thread and identify with boolean flag
+  [#87](https://github.com/bugsnag/bugsnag-java/pull/87)
+
 ## 3.2.0 (2018-07-03)
 
 This release introduces automatic tracking of sessions, which by


### PR DESCRIPTION
## Goal

Captures the trace of `Thread.currentThread()`, which was previously omitted, and to identify it with a boolean flag in the serialised JSON.

## Changeset

- Alter `ThreadState` to stop removing the current thread from serialisation
- Conditionally write `errorReportingThread` boolean flag by checking thread ID

## Tests

Added unit tests for general ThreadState serialisation, and for checking that the current thread is now captured.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
