### PR TITLE
Thread ID

### DIFF
--- a/src/main/java/com/bugsnag/Bugsnag.java
+++ b/src/main/java/com/bugsnag/Bugsnag.java
@@ -354,7 +354,7 @@ public class Bugsnag {
 
         HandledState handledState = HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_USER_SPECIFIED, severity);
-        Report report = new Report(config, throwable, handledState);
+        Report report = new Report(config, throwable, handledState, Thread.currentThread());
         return notify(report, callback);
     }
 
@@ -372,8 +372,8 @@ public class Bugsnag {
     }
 
 
-    boolean notify(Throwable throwable, HandledState handledState) {
-        Report report = new Report(config, throwable, handledState);
+    boolean notify(Throwable throwable, HandledState handledState, Thread currentThread) {
+        Report report = new Report(config, throwable, handledState, currentThread);
         return notify(report, null);
     }
 

--- a/src/main/java/com/bugsnag/ExceptionHandler.java
+++ b/src/main/java/com/bugsnag/ExceptionHandler.java
@@ -55,7 +55,7 @@ class ExceptionHandler implements UncaughtExceptionHandler {
 
             HandledState handledState = HandledState.newInstance(
                     HandledState.SeverityReasonType.REASON_UNHANDLED_EXCEPTION, Severity.ERROR);
-            bugsnag.notify(throwable, handledState);
+            bugsnag.notify(throwable, handledState, thread);
         }
 
         // Pass exception on to original exception handler

--- a/src/main/java/com/bugsnag/Report.java
+++ b/src/main/java/com/bugsnag/Report.java
@@ -24,6 +24,7 @@ public class Report {
     private Diagnostics diagnostics;
     private boolean shouldCancel = false;
     private Session session;
+    private final List<ThreadState> threadStates;
 
     /**
      * Create a report for the error.
@@ -33,15 +34,16 @@ public class Report {
      */
     protected Report(Configuration config, Throwable throwable) {
         this(config, throwable, HandledState.newInstance(
-                HandledState.SeverityReasonType.REASON_HANDLED_EXCEPTION));
+                HandledState.SeverityReasonType.REASON_HANDLED_EXCEPTION), Thread.currentThread());
     }
 
-    Report(Configuration config, Throwable throwable, HandledState handledState) {
+    Report(Configuration config, Throwable throwable, HandledState handledState, Thread currentThread) {
         this.config = config;
         this.exception = new Exception(config, throwable);
         this.handledState = handledState;
         this.severity = handledState.getOriginalSeverity();
         diagnostics = new Diagnostics(this.config);
+        threadStates = config.sendThreads ? ThreadState.getLiveThreads(config, currentThread) : null;
     }
 
     @Expose
@@ -80,7 +82,7 @@ public class Report {
 
     @Expose
     protected List<ThreadState> getThreads() {
-        return config.sendThreads ? ThreadState.getLiveThreads(config) : null;
+        return threadStates;
     }
 
     @Expose

--- a/src/main/java/com/bugsnag/ThreadState.java
+++ b/src/main/java/com/bugsnag/ThreadState.java
@@ -22,9 +22,9 @@ class ThreadState {
         this.stackTraceElements = stackTraceElements;
     }
 
-    static List<ThreadState> getLiveThreads(Configuration config) {
+    static List<ThreadState> getLiveThreads(Configuration config, Thread currentThread) {
         // Get current thread id (the crashing thread) and stacktraces for all live threads
-        long crashingThreadId = Thread.currentThread().getId();
+        long crashingThreadId = currentThread.getId();
         Map<Thread, StackTraceElement[]> liveThreads = Thread.getAllStackTraces();
 
         // Sort threads by thread-id

--- a/src/test/java/com/bugsnag/HandledStatePayloadTest.java
+++ b/src/test/java/com/bugsnag/HandledStatePayloadTest.java
@@ -107,7 +107,7 @@ public class HandledStatePayloadTest {
     }
 
     private Report reportFromHandledState(HandledState handledState) {
-        return new Report(config, new RuntimeException(), handledState);
+        return new Report(config, new RuntimeException(), handledState, Thread.currentThread());
     }
 
     private JsonNode getJsonPayloadFromReport(Report report) throws IOException {


### PR DESCRIPTION
## Goal

Captures the trace of `Thread.currentThread()`, which was previously omitted, and to identify it with a boolean flag in the serialised JSON.

## Changeset

- Capture thread traces on report generation, rather than serialisation
- Alter `ThreadState` to stop removing the current thread from serialisation
- Pass in the erroring thread to the `ThreadState` from either the current thread (handled) or crashing thread supplied by uncaughtExceptionHandler (unhandled)
- Conditionally write `errorReportingThread` boolean flag by checking thread ID

## Tests

Added unit tests for general ThreadState serialisation, and for checking that the current thread is now captured.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
