### PR TITLE
fix: add null check when disconnecting HttpUrlConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.2.1 (TBD)
+
+* Add null check when disconnecting HttpUrlConnection
+[#92](https://github.com/bugsnag/bugsnag-java/pull/92)
+
 ## 3.2.0 (2018-07-03)
 
 This release introduces automatic tracking of sessions, which by

--- a/src/main/java/com/bugsnag/delivery/SyncHttpDelivery.java
+++ b/src/main/java/com/bugsnag/delivery/SyncHttpDelivery.java
@@ -97,7 +97,9 @@ public class SyncHttpDelivery implements HttpDelivery {
         } catch (IOException ex) {
             logger.warn("Error not reported to Bugsnag - exception when making request", ex);
         } finally {
-            connection.disconnect();
+            if (connection != null) {
+                connection.disconnect();
+            }
         }
     }
 


### PR DESCRIPTION
## Goal

HttpUrlConnection may be null if the URL is malformed, or if a connection to the host could not be
opened. In this case `connection` will be null and no additional cleanup will be required.

## Changeset

Add null check in `finally` block if `connection` was not initialised.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
