### PR TITLE
Make constructors public for SyncHttpDelivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Add null check when disconnecting HttpUrlConnection
 [#92](https://github.com/bugsnag/bugsnag-java/pull/92)
 
+* Make constructors public for SyncHttpDelivery
+[#97](https://github.com/bugsnag/bugsnag-java/pull/97)
+
 ## 3.2.0 (2018-07-03)
 
 This release introduces automatic tracking of sessions, which by

--- a/src/main/java/com/bugsnag/delivery/SyncHttpDelivery.java
+++ b/src/main/java/com/bugsnag/delivery/SyncHttpDelivery.java
@@ -22,11 +22,21 @@ public class SyncHttpDelivery implements HttpDelivery {
     public static final String DEFAULT_SESSION_ENDPOINT = "https://sessions.bugsnag.com";
     protected static final int DEFAULT_TIMEOUT = 5000;
 
-    protected String endpoint = DEFAULT_NOTIFY_ENDPOINT;
+    protected String endpoint;
     protected int timeout = DEFAULT_TIMEOUT;
     protected Proxy proxy;
 
-    SyncHttpDelivery(String endpoint) {
+    /**
+     * Creates a new instance, which defaults to the https://notify.bugsnag.com endpoint
+     */
+    public SyncHttpDelivery() {
+        this(SyncHttpDelivery.DEFAULT_NOTIFY_ENDPOINT);
+    }
+
+    /**
+     * Creates a new instance, which uses a custom endpoint
+     */
+    public SyncHttpDelivery(String endpoint) {
         this.endpoint = endpoint;
     }
 


### PR DESCRIPTION
## Goal

Makes the constructors visible for `SyncHttpDelivery`, as per `AsyncHttpDelivery`. This allows external use of the synchronous delivery mechanism.

## Changeset

Made the `SyncHttpDelivery` constructor public and added a convenience zero-arg constructor.

## Tests

Ensured that no compilation errors occurred in an example app with different package for all `Delivery` implementations.

### Linked issues

Fixes #96 

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [x] Consistency between the changeset and the goal stated above
- [x] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [x] Usage friction - is the proposed change in usage cumbersome or complicated?
- [x] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [x] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [x] Idiomatic use of the language
