### PR TITLE
Update notifier payload info

### DIFF
--- a/bugsnag-spring/build.gradle
+++ b/bugsnag-spring/build.gradle
@@ -13,6 +13,8 @@ repositories {
 
 dependencies {
     compile project(':bugsnag')
+    testCompile project(path: ':bugsnag', configuration: 'testRuntime')
+
     compileOnly "javax.servlet:javax.servlet-api:${servletApiVersion}"
     compileOnly "org.springframework:spring-webmvc:${springVersion}"
     compileOnly "org.springframework.boot:spring-boot:${springBootVersion}"

--- a/bugsnag-spring/src/test/java/com/bugsnag/NotifierTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/NotifierTest.java
@@ -1,6 +1,7 @@
 package com.bugsnag;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -34,7 +35,7 @@ public class NotifierTest {
 
         assertEquals("Bugsnag Spring", notifier.get("name").asText());
         assertEquals("https://github.com/bugsnag/bugsnag-java", notifier.get("url").asText());
-        assertNotNull(notifier.get("version").asText());
+        assertFalse(notifier.get("version").asText().isEmpty());
     }
 
     @Test
@@ -44,6 +45,6 @@ public class NotifierTest {
 
         assertEquals("Bugsnag Spring", notifier.get("name").asText());
         assertEquals("https://github.com/bugsnag/bugsnag-java", notifier.get("url").asText());
-        assertNotNull(notifier.get("version").asText());
+        assertFalse(notifier.get("version").asText().isEmpty());
     }
 }

--- a/bugsnag-spring/src/test/java/com/bugsnag/NotifierTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/NotifierTest.java
@@ -1,13 +1,13 @@
 package com.bugsnag;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class NotifierTest {
 

--- a/bugsnag-spring/src/test/java/com/bugsnag/NotifierTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/NotifierTest.java
@@ -1,0 +1,49 @@
+package com.bugsnag;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class NotifierTest {
+
+    private Report report;
+    private Configuration config;
+    private SessionPayload sessionPayload;
+
+    /**
+     * Initialises the objectmapper + report for conversion to json
+     *
+     * @throws Throwable the throwable
+     */
+    @Before
+    public void setUp() throws Throwable {
+        config = new Configuration("api-key");
+        report = new Report(config, new RuntimeException());
+        sessionPayload = new SessionPayload(Collections.<SessionCount>emptyList(), config);
+    }
+
+    @Test
+    public void testNotificationSerialisation() throws Throwable {
+        JsonNode payload = BugsnagTestUtils.mapReportToJson(config, this.report);
+        JsonNode notifier = payload.get("notifier");
+
+        assertEquals("Bugsnag Spring", notifier.get("name").asText());
+        assertEquals("https://github.com/bugsnag/bugsnag-java", notifier.get("url").asText());
+        assertNotNull(notifier.get("version").asText());
+    }
+
+    @Test
+    public void testSessionSerialisation() throws Throwable {
+        JsonNode payload = BugsnagTestUtils.mapSessionPayloadToJson(sessionPayload);
+        JsonNode notifier = payload.get("notifier");
+
+        assertEquals("Bugsnag Spring", notifier.get("name").asText());
+        assertEquals("https://github.com/bugsnag/bugsnag-java", notifier.get("url").asText());
+        assertNotNull(notifier.get("version").asText());
+    }
+}

--- a/bugsnag/build.gradle
+++ b/bugsnag/build.gradle
@@ -22,3 +22,12 @@ dependencies {
         exclude group: "org.slf4j"
     }
 }
+
+task testJar(type: Jar) {
+    classifier = 'test'
+    from sourceSets.test.output
+}
+
+artifacts {
+    testRuntime testJar
+}

--- a/bugsnag/src/main/java/com/bugsnag/Notification.java
+++ b/bugsnag/src/main/java/com/bugsnag/Notification.java
@@ -2,7 +2,6 @@ package com.bugsnag;
 
 import com.bugsnag.serialization.Expose;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -23,7 +22,7 @@ class Notification {
 
     @Expose
     public Notifier getNotifier() {
-        return new Notifier();
+        return NotifierUtils.getNotifier();
     }
 
     @Expose

--- a/bugsnag/src/main/java/com/bugsnag/Notifier.java
+++ b/bugsnag/src/main/java/com/bugsnag/Notifier.java
@@ -3,13 +3,20 @@ package com.bugsnag;
 import com.bugsnag.serialization.Expose;
 
 class Notifier {
+
     private static final String NOTIFIER_NAME = "Bugsnag Java";
     private static final String NOTIFIER_VERSION = "3.3.0";
     private static final String NOTIFIER_URL = "https://github.com/bugsnag/bugsnag-java";
 
+    private String notifierName = NOTIFIER_NAME;
+
+    void setNotifierName(String notifierName) {
+        this.notifierName = notifierName;
+    }
+
     @Expose
     public String getName() {
-        return NOTIFIER_NAME;
+        return notifierName;
     }
 
     @Expose

--- a/bugsnag/src/main/java/com/bugsnag/NotifierUtils.java
+++ b/bugsnag/src/main/java/com/bugsnag/NotifierUtils.java
@@ -1,0 +1,26 @@
+package com.bugsnag;
+
+class NotifierUtils {
+
+    private static final boolean IS_SPRING_NOTIFIER = hasBugsnagSpringClz();
+    private static final String BUGSNAG_SPRING_CLZ = "com.bugsnag.BugsnagSpringConfiguration";
+
+    private static boolean hasBugsnagSpringClz() {
+        try {
+            Class.forName(BUGSNAG_SPRING_CLZ, false, NotifierUtils.class.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException ex) {
+            return false;
+        }
+    }
+
+    static Notifier getNotifier() {
+        Notifier notifier = new Notifier();
+
+        if (IS_SPRING_NOTIFIER) {
+            notifier.setNotifierName("Bugsnag Spring");
+        }
+        return notifier;
+    }
+
+}

--- a/bugsnag/src/main/java/com/bugsnag/SessionPayload.java
+++ b/bugsnag/src/main/java/com/bugsnag/SessionPayload.java
@@ -2,7 +2,6 @@ package com.bugsnag;
 
 import com.bugsnag.serialization.Expose;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
@@ -18,7 +17,7 @@ final class SessionPayload {
 
     @Expose
     Notifier getNotifier() {
-        return new Notifier();
+        return NotifierUtils.getNotifier();
     }
 
     @Expose

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagTestUtils.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagTestUtils.java
@@ -2,6 +2,7 @@ package com.bugsnag;
 
 import com.bugsnag.delivery.Delivery;
 import com.bugsnag.serialization.Serializer;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagTestUtils.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagTestUtils.java
@@ -2,7 +2,10 @@ package com.bugsnag;
 
 import com.bugsnag.delivery.Delivery;
 import com.bugsnag.serialization.Serializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.io.IOException;
 import java.util.Map;
 
 class BugsnagTestUtils {
@@ -19,5 +22,18 @@ class BugsnagTestUtils {
 
             }
         };
+    }
+
+    static JsonNode mapReportToJson(Configuration config, Report report) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        Notification notification = new Notification(config, report);
+        String json = mapper.writeValueAsString(notification);
+        return mapper.readTree(json);
+    }
+
+    static JsonNode mapSessionPayloadToJson(SessionPayload sessionPayload) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(sessionPayload);
+        return mapper.readTree(json);
     }
 }

--- a/bugsnag/src/test/java/com/bugsnag/NotifierTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/NotifierTest.java
@@ -1,0 +1,49 @@
+package com.bugsnag;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class NotifierTest {
+
+    private Report report;
+    private Configuration config;
+    private SessionPayload sessionPayload;
+
+    /**
+     * Initialises the objectmapper + report for conversion to json
+     *
+     * @throws Throwable the throwable
+     */
+    @Before
+    public void setUp() throws Throwable {
+        config = new Configuration("api-key");
+        report = new Report(config, new RuntimeException());
+        sessionPayload = new SessionPayload(Collections.<SessionCount>emptyList(), config);
+    }
+
+    @Test
+    public void testNotificationSerialisation() throws Throwable {
+        JsonNode payload = BugsnagTestUtils.mapReportToJson(config, this.report);
+        JsonNode notifier = payload.get("notifier");
+
+        assertEquals("Bugsnag Java", notifier.get("name").asText());
+        assertEquals("https://github.com/bugsnag/bugsnag-java", notifier.get("url").asText());
+        assertNotNull(notifier.get("version").asText());
+    }
+
+    @Test
+    public void testSessionSerialisation() throws Throwable {
+        JsonNode payload = BugsnagTestUtils.mapSessionPayloadToJson(sessionPayload);
+        JsonNode notifier = payload.get("notifier");
+
+        assertEquals("Bugsnag Java", notifier.get("name").asText());
+        assertEquals("https://github.com/bugsnag/bugsnag-java", notifier.get("url").asText());
+        assertNotNull(notifier.get("version").asText());
+    }
+}

--- a/bugsnag/src/test/java/com/bugsnag/NotifierTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/NotifierTest.java
@@ -1,13 +1,13 @@
 package com.bugsnag;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class NotifierTest {
 

--- a/bugsnag/src/test/java/com/bugsnag/NotifierTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/NotifierTest.java
@@ -1,6 +1,7 @@
 package com.bugsnag;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -34,7 +35,7 @@ public class NotifierTest {
 
         assertEquals("Bugsnag Java", notifier.get("name").asText());
         assertEquals("https://github.com/bugsnag/bugsnag-java", notifier.get("url").asText());
-        assertNotNull(notifier.get("version").asText());
+        assertFalse(notifier.get("version").asText().isEmpty());
     }
 
     @Test
@@ -44,6 +45,6 @@ public class NotifierTest {
 
         assertEquals("Bugsnag Java", notifier.get("name").asText());
         assertEquals("https://github.com/bugsnag/bugsnag-java", notifier.get("url").asText());
-        assertNotNull(notifier.get("version").asText());
+        assertFalse(notifier.get("version").asText().isEmpty());
     }
 }


### PR DESCRIPTION
## Goal

Updates the Notifier name in error/session payloads if the notifier is bugsnag-spring.

## Changeset

Adds a `NotifierUtils` class which checks whether the `BugsnagSpringConfiguration` class is available on the classloader. This is a good proxy for determining whether the notifier is `bugsnag-spring` or `bugsnag-java`.

## Tests

Added unit tests for serialisation, manual test of example plain/spring apps.