### PR TITLE
Add upgrade and changelog for Spring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## TBD
+
+Two artifacts are now available for this platform:
+
+- `bugsnag-java` - intended for plain Java applications
+- `bugsnag-spring` - provides enhanced support for Spring applications
+
+It is recommended that you migrate to `bugsnag-spring` if you develop a Spring application, as it enhances the quantity and quality of error reports which are sent automatically. Full upgrade instructions can be found [here](UPGRADING.md).
+
+No upgrade steps are required for `bugsnag-java` in this release.
+
+* Added `BugsnagAppender` that can report throwables from existing log statements to Bugsnag, using [logback](https://logback.qos.ch/)
+* [Spring] Automatically report exceptions thrown when processing MVC/REST requests
+* [Spring] Automatically report exceptions thrown in scheduled tasks
+* [Spring] Added `BugsnagAsyncConfig` class to simplify capture of uncaught exceptions in async tasks
+* [Spring] Automatically attach request metadata to reports
+* [Spring] Automatically attach Spring version information to reports
+* [Spring] Automatically track sessions for each MVC request
+
+See [UPGRADING](UPGRADING.md) for upgrade details and [the docs](https://docs.bugsnag.com/platforms/java/spring) for further information on new functionality.
+
 ## 3.3.0 (2018-09-26)
 
 * Capture trace of error reporting thread and identify with boolean flag

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,31 @@
 Upgrading
 =========
 
+## Migrating from bugsnag-java to bugsnag-spring
+
+If you develop a [Spring Framework](https://spring.io/) application, it is recommended that you migrate from bugsnag-java to bugsnag-spring. bugsnag-spring adds support for various Spring-specific features, such as automatic detection of exceptions within scheduled tasks. To upgrade:
+
+1. Replace the `bugsnag` artefact with `bugsnag-spring` in your build.gradle:
+
+```groovy
+//compile 'com.bugsnag:bugsnag:3.+'
+compile 'com.bugsnag:bugsnag-spring:3.+'
+```
+
+2. Create a Spring `Configuration` class which exposes `Bugsnag` as a Spring bean and imports the configuration class `BugsnagSpringConfiguration`. This should replace any previous instantiation of `Bugsnag`:
+
+```java
+@Configuration
+@Import(BugsnagSpringConfiguration.class)
+public class BugsnagConfig {
+    @Bean
+    public Bugsnag bugsnag() {
+        return Bugsnag.init("your-api-key-here");
+    }
+}
+```
+
+3. If you wish to configure Logback, capture uncaught exceptions in async methods, or otherwise customise your integration, please [see the docs](https://docs.bugsnag.com/platforms/java/spring/#installation) for further information.
 
 ## 2.x to 3.x
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,7 +5,7 @@ Upgrading
 
 If you develop a [Spring Framework](https://spring.io/) application, it is recommended that you migrate from bugsnag-java to bugsnag-spring. bugsnag-spring adds support for various Spring-specific features, such as automatic detection of exceptions within scheduled tasks. To upgrade:
 
-1. Replace the `bugsnag` artefact with `bugsnag-spring` in your build.gradle:
+1. Replace the `bugsnag` artifact with `bugsnag-spring` in your build.gradle:
 
 ```groovy
 //compile 'com.bugsnag:bugsnag:3.+'


### PR DESCRIPTION
This changeset adds a migration guide for moving a plain Java app to use the bugsnag-spring artifact. It also adds a changelog entry that briefly explains:

- Whether to use bugsnag-java or bugsnag-spring
- Links to upgrade steps/further documentation
- High-level summary of new functionality