### PR TITLE
Add callbacks via markers

### DIFF
--- a/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
@@ -15,6 +15,7 @@ import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.classic.spi.ThrowableProxy;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Marker;
 
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -142,8 +143,9 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
             Throwable throwable = extractThrowable(event);
 
             final Callback reportCallback;
-            if (event.getMarker() != null && event.getMarker() instanceof BugsnagMarker) {
-                reportCallback = ((BugsnagMarker) event.getMarker()).getCallback();
+            Marker marker = event.getMarker();
+            if (marker instanceof BugsnagMarker) {
+                reportCallback = ((BugsnagMarker) marker).getCallback();
             } else {
                 reportCallback = null;
             }

--- a/bugsnag/src/main/java/com/bugsnag/logback/BugsnagMarker.java
+++ b/bugsnag/src/main/java/com/bugsnag/logback/BugsnagMarker.java
@@ -1,6 +1,7 @@
 package com.bugsnag.logback;
 
 import com.bugsnag.callbacks.Callback;
+
 import org.slf4j.Marker;
 
 import java.util.ArrayList;

--- a/bugsnag/src/main/java/com/bugsnag/logback/BugsnagMarker.java
+++ b/bugsnag/src/main/java/com/bugsnag/logback/BugsnagMarker.java
@@ -13,6 +13,8 @@ import java.util.List;
  */
 public class BugsnagMarker implements Marker {
 
+    private static final long serialVersionUID = -8536034181100363313L;
+
     private static final String BUGSNAG_MARKER_NAME = "BUGSNAG_MARKER";
 
     private Callback callback;
@@ -27,10 +29,6 @@ public class BugsnagMarker implements Marker {
         return callback;
     }
 
-    public void setCallback(Callback callback) {
-        this.callback = callback;
-    }
-
     @Override
     public String getName() {
         return BUGSNAG_MARKER_NAME;
@@ -38,7 +36,7 @@ public class BugsnagMarker implements Marker {
 
     @Override
     public void add(Marker reference) {
-
+        references.add(reference);
     }
 
     @Override

--- a/bugsnag/src/main/java/com/bugsnag/logback/BugsnagMarker.java
+++ b/bugsnag/src/main/java/com/bugsnag/logback/BugsnagMarker.java
@@ -1,0 +1,78 @@
+package com.bugsnag.logback;
+
+import com.bugsnag.callbacks.Callback;
+import org.slf4j.Marker;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Marker used to pass a callback through a logger call
+ */
+public class BugsnagMarker implements Marker {
+
+    private static final String BUGSNAG_MARKER_NAME = "BUGSNAG_MARKER";
+
+    private Callback callback;
+
+    private List<Marker> references = new ArrayList<Marker>();
+
+    public BugsnagMarker(Callback callback) {
+        this.callback = callback;
+    }
+
+    public Callback getCallback() {
+        return callback;
+    }
+
+    public void setCallback(Callback callback) {
+        this.callback = callback;
+    }
+
+    @Override
+    public String getName() {
+        return BUGSNAG_MARKER_NAME;
+    }
+
+    @Override
+    public void add(Marker reference) {
+
+    }
+
+    @Override
+    public boolean remove(Marker reference) {
+        return references.remove(reference);
+    }
+
+    @Override
+    public boolean hasChildren() {
+        return hasReferences();
+    }
+
+    @Override
+    public boolean hasReferences() {
+        return references.size() > 0;
+    }
+
+    @Override
+    public Iterator<Marker> iterator() {
+        return references.iterator();
+    }
+
+    @Override
+    public boolean contains(Marker other) {
+        return references.contains(other);
+    }
+
+    @Override
+    public boolean contains(String name) {
+        for (Marker reference : references) {
+            if (reference.getName().equals(name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/bugsnag/src/test/java/com/bugsnag/AppenderMetaDataTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderMetaDataTest.java
@@ -8,17 +8,15 @@ import static org.junit.Assert.assertTrue;
 
 import com.bugsnag.callbacks.Callback;
 import com.bugsnag.delivery.Delivery;
-
 import com.bugsnag.logback.BugsnagMarker;
-import org.slf4j.Logger;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**

--- a/bugsnag/src/test/java/com/bugsnag/MarkerTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/MarkerTest.java
@@ -1,0 +1,85 @@
+package com.bugsnag;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.bugsnag.callbacks.Callback;
+import com.bugsnag.logback.BugsnagMarker;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Marker;
+
+import java.util.Iterator;
+
+
+/**
+ * Tests for the Bugsnag Marker internal logic
+ */
+public class MarkerTest {
+
+    private BugsnagMarker marker;
+    private Callback callback;
+
+    /**
+     * Create the marker before the tests
+     */
+    @Before
+    public void createMarker() {
+        callback = new Callback() {
+            @Override
+            public void beforeNotify(Report report) {
+
+            }
+        };
+
+        marker = new BugsnagMarker(callback);
+    }
+
+    @Test
+    public void testMarkerCallback() {
+
+        // Check that the callback is set as expected
+        assertEquals(callback, marker.getCallback());
+    }
+
+    @Test
+    public void testMarkerName() {
+        assertEquals("BUGSNAG_MARKER", marker.getName());
+    }
+
+    @Test
+    public void testMarkerAddReference() {
+
+        assertFalse(marker.hasReferences());
+        assertFalse(marker.hasChildren());
+
+        Marker newMarker = new BugsnagMarker(callback);
+        marker.add(newMarker);
+
+        assertTrue(marker.hasReferences());
+        assertTrue(marker.hasChildren());
+        assertTrue(marker.contains(newMarker));
+        assertTrue(marker.contains(newMarker.getName()));
+
+        Iterator<Marker> iterator = marker.iterator();
+        assertEquals(newMarker,iterator.next());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testMarkerRemoveReference() {
+
+        Marker newMarker = new BugsnagMarker(callback);
+        marker.add(newMarker);
+
+        assertTrue(marker.hasReferences());
+        assertTrue(marker.hasChildren());
+
+        marker.remove(newMarker);
+
+        assertFalse(marker.hasReferences());
+        assertFalse(marker.hasChildren());
+    }
+}

--- a/examples/logback/src/main/java/com/bugsnag/example/logback/cli/Application.java
+++ b/examples/logback/src/main/java/com/bugsnag/example/logback/cli/Application.java
@@ -44,6 +44,17 @@ public class Application {
             LOGGER.info(e.getMessage(), e);
         }
 
+        // Send a handled exception with custom MetaData
+        LOGGER.info("Sending a handled exception to Bugsnag with custom MetaData");
+        try {
+            throw new RuntimeException("Handled exception - custom metadata");
+        } catch (RuntimeException e) {
+            LOGGER.warn(new BugsnagMarker((report) -> {
+                report.addToTab("report tab", "data key 1", "data value 1");
+                report.addToTab("report tab", "data key 2", "data value 2");
+            }), "Something bad happened", e);
+        }
+
         // Test an unhandled exception from a different thread as shutdown hooks
         // won't be called if executed from this thread
         LOGGER.info("Sending an unhandled exception to Bugsnag");
@@ -58,10 +69,6 @@ public class Application {
 
         // Wait for unhandled exception thread to finish before exiting
         thread.join();
-
-        LOGGER.error(new BugsnagMarker((report) -> {
-            report.addToTab("report", "key1", "value added in callback");
-        }), "Something bad happend", new RuntimeException("Something bad happened"));
 
         // Remove the thread meta data so it won't be added to future reports on this thread
         Bugsnag.clearThreadMetaData();

--- a/examples/logback/src/main/java/com/bugsnag/example/logback/cli/Application.java
+++ b/examples/logback/src/main/java/com/bugsnag/example/logback/cli/Application.java
@@ -1,8 +1,10 @@
 package com.bugsnag.example.logback.cli;
 
 import com.bugsnag.BugsnagAppender;
+import com.bugsnag.logback.BugsnagMarker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
 
 import java.util.Date;
 
@@ -55,6 +57,10 @@ public class Application {
 
         // Wait for unhandled exception thread to finish before exiting
         thread.join();
+
+        LOGGER.error(new BugsnagMarker((report) -> {
+            report.addToTab("report", "key1", "value added in callback");
+        }), "Something bad happend", new RuntimeException("Something bad happened"));
 
         // Remove the thread meta data so it won't be added to future reports on this thread
         BugsnagAppender.clearThreadMetaData();

--- a/features/filtering_metadata.feature
+++ b/features/filtering_metadata.feature
@@ -20,7 +20,7 @@ Scenario: Adding a custom metadata filter
     And the event "metaData.user.foo" equals "[FILTERED]"
     And the event "metaData.custom.bar" equals "hunter2"
 
-Scenario: Adding a custom metadata filter using logback
+Scenario: Adding a thread metadata filter using logback
     When I run "LogbackThreadMetaDataScenario" with logback config "meta_data_filter_config.xml"
     Then I should receive a request
     And the request is a valid for the error reporting API
@@ -28,6 +28,16 @@ Scenario: Adding a custom metadata filter using logback
     And the exception "message" equals "LogbackThreadMetaDataScenario"
     And the event "metaData.thread.foo" equals "[FILTERED]"
     And the event "metaData.thread.bar" equals "threadvalue2"
+
+Scenario: Adding a custom metadata filter using logback
+    When I run "LogbackMetaDataScenario" with logback config "meta_data_filter_config.xml"
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the exception "message" equals "LogbackMetaDataScenario"
+    And the event "metaData.custom.foo" equals "[FILTERED]"
+    And the event "metaData.user.foo" equals "[FILTERED]"
+    And the event "metaData.custom.bar" equals "hunter2"
 
 Scenario: Using the default metadata filter in Spring Boot app
     When I run spring boot "AutoFilterScenario" with the defaults

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/LogbackMetaDataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/LogbackMetaDataScenario.java
@@ -1,0 +1,33 @@
+package com.bugsnag.mazerunner.scenarios;
+
+import com.bugsnag.Bugsnag;
+import com.bugsnag.Report;
+import com.bugsnag.callbacks.Callback;
+import com.bugsnag.logback.BugsnagMarker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Sends an exception to Bugsnag with custom meta data using the logback appender
+ */
+public class LogbackMetaDataScenario extends Scenario {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogbackMetaDataScenario.class);
+
+    public LogbackMetaDataScenario(Bugsnag bugsnag) {
+        super(bugsnag);
+    }
+
+    @Override
+    public void run() {
+        LOGGER.warn(new BugsnagMarker(new Callback() {
+                    @Override
+                    public void beforeNotify(Report report) {
+                        report.addToTab("user", "foo", "hunter2");
+                        report.addToTab("custom", "foo", "hunter2");
+                        report.addToTab("custom", "bar", "hunter2");
+                    }
+                }),"Error sent to Bugsnag using the logback appender", generateException());
+    }
+}

--- a/features/meta_data.feature
+++ b/features/meta_data.feature
@@ -32,7 +32,7 @@ Scenario: Test logback appender with meta data in the config file
     And the event "metaData.configTab.foo" equals "tabValue1"
     And the event "metaData.configTab.bar" equals "tabValue2"
 
-Scenario: Test logback appender with meta data in a callback
+Scenario: Test logback appender with thread meta data
     When I run "LogbackThreadMetaDataScenario" with logback config "basic_config.xml"
     Then I should receive a request
     And the request is a valid for the error reporting API
@@ -41,6 +41,17 @@ Scenario: Test logback appender with meta data in a callback
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the event "metaData.thread.foo" equals "threadvalue1"
     And the event "metaData.thread.bar" equals "threadvalue2"
+
+Scenario: Test logback appender with meta data in a callback
+    When I run "LogbackMetaDataScenario" with logback config "basic_config.xml"
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the payload field "events" is an array with 1 element
+    And the exception "errorClass" equals "java.lang.RuntimeException"
+    And the event "metaData.user.foo" equals "hunter2"
+    And the event "metaData.custom.foo" equals "hunter2"
+    And the event "metaData.custom.bar" equals "hunter2"
 
 Scenario: Test thread meta data
     When I run "ThreadMetaDataScenario" with the defaults


### PR DESCRIPTION
## Goal

Allow meta data to be added to individual logger statements via a custom marker object

## Design

Previously we used a custom exception, but using a marker is viewed as a slightly cleaner approach

## Review

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
