### PR TITLE
Allow thread meta data to be read

### DIFF
--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -446,6 +446,9 @@ public class Bugsnag {
             return false;
         }
 
+        // Add thread metadata to the report
+        report.mergeMetaData(THREAD_METADATA.get());
+
         // Run all client-wide beforeNotify callbacks
         for (Callback callback : config.callbacks) {
             try {
@@ -462,9 +465,6 @@ public class Bugsnag {
                 LOGGER.warn("Callback threw an exception", ex);
             }
         }
-
-        // Add thread metadata to the report
-        report.mergeMetaData(THREAD_METADATA.get());
 
         // Run the report-specific beforeNotify callback, if given
         if (reportCallback != null) {
@@ -631,6 +631,13 @@ public class Bugsnag {
      */
     public static void clearThreadMetaData(String tabName, String key) {
         THREAD_METADATA.get().clearKey(tabName, key);
+    }
+
+    /**
+     * @return Thread meta data for the current thread
+     */
+    public static MetaData getThreadMetaData() {
+        return THREAD_METADATA.get();
     }
 
     Configuration getConfig() {

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ThreadMetaDataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ThreadMetaDataScenario.java
@@ -15,18 +15,19 @@ public class ThreadMetaDataScenario extends Scenario {
 
     @Override
     public void run() {
-        // Global callback metadata has lowest precedence
+
+        // Thread metadata has the lowest precedence
+        Bugsnag.addThreadMetaData("Custom", "test", "Thread value");
+        Bugsnag.addThreadMetaData("Custom", "foo", "Thread value to be overwritten");
+        Bugsnag.addThreadMetaData("Custom", "bar", "Thread value to be overwritten");
+
+        // Global callback metadata should overwrite thread meta data
         bugsnag.addCallback(new Callback() {
             @Override
             public void beforeNotify(Report report) {
-                report.addToTab("Custom", "test", "Global value");
-                report.addToTab("Custom", "foo", "Global value to be overwritten");
+                report.addToTab("Custom", "foo", "Global value");
             }
         });
-
-        // Thread metadata should merge with global metadata and overwrite when duplicate key
-        Bugsnag.addThreadMetaData("Custom", "foo", "Thread value");
-        Bugsnag.addThreadMetaData("Custom", "bar", "Thread value to be overwritten");
 
         // Thread metadata on a different thread should not get added
         Thread t1 = new Thread(new Runnable() {

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UnhandledThreadMetaDataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UnhandledThreadMetaDataScenario.java
@@ -15,12 +15,11 @@ public class UnhandledThreadMetaDataScenario extends Scenario {
 
     @Override
     public void run() {
-        // Global callback metadata has lowest precedence
+        // Global callback metadata should overwrite thread meta data
         bugsnag.addCallback(new Callback() {
             @Override
             public void beforeNotify(Report report) {
-                report.addToTab("Custom", "test", "Global value");
-                report.addToTab("Custom", "foo", "Global value to be overwritten");
+                report.addToTab("Custom", "foo", "Global value");
             }
         });
 
@@ -42,9 +41,9 @@ public class UnhandledThreadMetaDataScenario extends Scenario {
         Thread t2 = new Thread(new Runnable() {
             @Override
             public void run() {
-                // Thread metadata should merge with global metadata and overwrite when duplicate key
-                Bugsnag.addThreadMetaData("Custom", "foo", "Thread value 1");
-                Bugsnag.addThreadMetaData("Custom", "bar", "Thread value 2");
+                // Thread metadata should be overwritten by global callback
+                Bugsnag.addThreadMetaData("Custom", "test", "Thread value");
+                Bugsnag.addThreadMetaData("Custom", "foo", "Thread value to be overwritten");
                 throw new RuntimeException("UnhandledThreadMetaDataScenario");
             }
         });

--- a/features/meta_data.feature
+++ b/features/meta_data.feature
@@ -70,8 +70,8 @@ Scenario: Test thread meta data
     And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
     And the payload field "events" is an array with 1 element
     And the exception "errorClass" equals "java.lang.RuntimeException"
-    And the event "metaData.Custom.test" equals "Global value"
-    And the event "metaData.Custom.foo" equals "Thread value"
+    And the event "metaData.Custom.test" equals "Thread value"
+    And the event "metaData.Custom.foo" equals "Global value"
     And the event "metaData.Custom.bar" equals "Hello World!"
     And the event "metaData.Custom.something" is null
 
@@ -82,8 +82,8 @@ Scenario: Test thread meta data for Spring Boot app
     And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
     And the payload field "events" is an array with 1 element
     And the exception "errorClass" equals "java.lang.RuntimeException"
-    And the event "metaData.Custom.test" equals "Global value"
-    And the event "metaData.Custom.foo" equals "Thread value"
+    And the event "metaData.Custom.test" equals "Thread value"
+    And the event "metaData.Custom.foo" equals "Global value"
     And the event "metaData.Custom.bar" equals "Hello World!"
     And the event "metaData.Custom.something" is null
 
@@ -94,8 +94,8 @@ Scenario: Test thread meta data for plain Spring app
     And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
     And the payload field "events" is an array with 1 element
     And the exception "errorClass" equals "java.lang.RuntimeException"
-    And the event "metaData.Custom.test" equals "Global value"
-    And the event "metaData.Custom.foo" equals "Thread value"
+    And the event "metaData.Custom.test" equals "Thread value"
+    And the event "metaData.Custom.foo" equals "Global value"
     And the event "metaData.Custom.bar" equals "Hello World!"
     And the event "metaData.Custom.something" is null
 
@@ -107,8 +107,7 @@ Scenario: Test unhandled thread meta data
     And the payload field "events" is an array with 1 element
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the event "metaData.Custom.test" equals "Global value"
-    And the event "metaData.Custom.foo" equals "Thread value 1"
-    And the event "metaData.Custom.bar" equals "Thread value 2"
+    And the event "metaData.Custom.foo" equals "Thread value"
     And the event "metaData.Custom.something" is null
 
 Scenario: Test unhandled thread meta data for Spring Boot app
@@ -119,8 +118,7 @@ Scenario: Test unhandled thread meta data for Spring Boot app
     And the payload field "events" is an array with 1 element
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the event "metaData.Custom.test" equals "Global value"
-    And the event "metaData.Custom.foo" equals "Thread value 1"
-    And the event "metaData.Custom.bar" equals "Thread value 2"
+    And the event "metaData.Custom.foo" equals "Thread value"
     And the event "metaData.Custom.something" is null
 
 Scenario: Test unhandled thread meta data for plain Spring app
@@ -131,8 +129,7 @@ Scenario: Test unhandled thread meta data for plain Spring app
     And the payload field "events" is an array with 1 element
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the event "metaData.Custom.test" equals "Global value"
-    And the event "metaData.Custom.foo" equals "Thread value 1"
-    And the event "metaData.Custom.bar" equals "Thread value 2"
+    And the event "metaData.Custom.foo" equals "Thread value"
     And the event "metaData.Custom.something" is null
 
 Scenario: Test logback appender with thread meta data

--- a/features/meta_data.feature
+++ b/features/meta_data.feature
@@ -106,8 +106,8 @@ Scenario: Test unhandled thread meta data
     And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
     And the payload field "events" is an array with 1 element
     And the exception "errorClass" equals "java.lang.RuntimeException"
-    And the event "metaData.Custom.test" equals "Global value"
-    And the event "metaData.Custom.foo" equals "Thread value"
+    And the event "metaData.Custom.test" equals "Thread value"
+    And the event "metaData.Custom.foo" equals "Global value"
     And the event "metaData.Custom.something" is null
 
 Scenario: Test unhandled thread meta data for Spring Boot app
@@ -117,8 +117,8 @@ Scenario: Test unhandled thread meta data for Spring Boot app
     And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
     And the payload field "events" is an array with 1 element
     And the exception "errorClass" equals "java.lang.RuntimeException"
-    And the event "metaData.Custom.test" equals "Global value"
-    And the event "metaData.Custom.foo" equals "Thread value"
+    And the event "metaData.Custom.test" equals "Thread value"
+    And the event "metaData.Custom.foo" equals "Global value"
     And the event "metaData.Custom.something" is null
 
 Scenario: Test unhandled thread meta data for plain Spring app
@@ -128,8 +128,8 @@ Scenario: Test unhandled thread meta data for plain Spring app
     And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
     And the payload field "events" is an array with 1 element
     And the exception "errorClass" equals "java.lang.RuntimeException"
-    And the event "metaData.Custom.test" equals "Global value"
-    And the event "metaData.Custom.foo" equals "Thread value"
+    And the event "metaData.Custom.test" equals "Thread value"
+    And the event "metaData.Custom.foo" equals "Global value"
     And the event "metaData.Custom.something" is null
 
 Scenario: Test logback appender with thread meta data


### PR DESCRIPTION
## Goal

Currently it is not possible to read information from thread meta data out of the library, it is possible that someone would want to do this as part of the logging process.

The thread meta data should also be merged before the global callbacks are run, so that they can have access to a more complete report.

## Review

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
