### PR TITLE
Specify maven central as a preferred repository over jcenter

### DIFF
--- a/bugsnag-spring/build.gradle
+++ b/bugsnag-spring/build.gradle
@@ -8,6 +8,7 @@ apply plugin: 'java-library'
 apply from: '../common.gradle'
 
 repositories {
+    mavenCentral()
     jcenter()
 }
 

--- a/bugsnag/build.gradle
+++ b/bugsnag/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'java-library'
 apply from: '../common.gradle'
 
 repositories {
+    mavenCentral()
     jcenter()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        mavenCentral()
         jcenter()
     }
     dependencies {

--- a/examples/logback/build.gradle
+++ b/examples/logback/build.gradle
@@ -2,11 +2,13 @@ apply plugin: 'application'
 
 buildscript {
     repositories {
+        mavenCentral()
         jcenter()
     }
 }
 
 repositories {
+    mavenCentral()
     jcenter()
 }
 

--- a/examples/servlet/build.gradle
+++ b/examples/servlet/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.akhikhl.gretty'
 
 buildscript {
     repositories {
+        mavenCentral()
         jcenter()
     }
 
@@ -13,6 +14,7 @@ buildscript {
 }
 
 repositories {
+    mavenCentral()
     jcenter()
 }
 

--- a/examples/simple/build.gradle
+++ b/examples/simple/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'application'
 
 repositories {
+    mavenCentral()
     jcenter()
 }
 

--- a/examples/spring-web/build.gradle
+++ b/examples/spring-web/build.gradle
@@ -5,6 +5,7 @@ buildscript {
         springBootVersion = '1.4.1.RELEASE'
     }
     repositories {
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -13,6 +14,7 @@ buildscript {
 }
 
 repositories {
+    mavenCentral()
     jcenter()
 }
 

--- a/examples/spring/build.gradle
+++ b/examples/spring/build.gradle
@@ -5,6 +5,7 @@ buildscript {
         springBootVersion = '1.4.1.RELEASE'
     }
     repositories {
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -13,6 +14,7 @@ buildscript {
 }
 
 repositories {
+    mavenCentral()
     jcenter()
 }
 

--- a/features/fixtures/mazerunner/build.gradle
+++ b/features/fixtures/mazerunner/build.gradle
@@ -3,6 +3,7 @@ buildscript {
         springBootVersion = '2.0.5.RELEASE'
     }
     repositories {
+        mavenCentral()
         jcenter()
     }
     dependencies {

--- a/features/fixtures/mazerunnerspringboot/build.gradle
+++ b/features/fixtures/mazerunnerspringboot/build.gradle
@@ -3,6 +3,7 @@ buildscript {
         springBootVersion = '2.0.5.RELEASE'
     }
     repositories {
+        mavenCentral()
         jcenter()
     }
     dependencies {


### PR DESCRIPTION
## Goal

Specifying `mavenCentral` as a repository in addition to `jcenter` makes it possible to perform a clean build of the project in the case where one provider suffers downtime.