### PR TITLE
Support other methods of configuring a TaskScheduler

### DIFF
--- a/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
@@ -38,6 +38,11 @@ public class BugsnagSpringConfiguration {
         return callback;
     }
 
+    @Bean
+    ScheduledTaskBeanLocator scheduledTaskBeanLocator() {
+        return new ScheduledTaskBeanLocator();
+    }
+
     /**
      * If using Logback, stop any configured appender from creating Bugsnag reports for Spring log
      * messages as they effectively duplicate error reports for unhandled exceptions.

--- a/bugsnag-spring/src/main/java/com/bugsnag/ScheduledTaskBeanLocator.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/ScheduledTaskBeanLocator.java
@@ -3,6 +3,7 @@ package com.bugsnag;
 import static org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor.DEFAULT_TASK_SCHEDULER_BEAN_NAME;
 
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanNotOfRequiredTypeException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
@@ -25,11 +26,11 @@ class ScheduledTaskBeanLocator implements ApplicationContextAware {
         this.beanFactory = applicationContext;
     }
 
-    public TaskScheduler resolveTaskScheduler() {
+    TaskScheduler resolveTaskScheduler() {
         return resolveSchedulerBean(TaskScheduler.class);
     }
 
-    public ScheduledExecutorService resolveScheduledExecutorService() {
+    ScheduledExecutorService resolveScheduledExecutorService() {
         return resolveSchedulerBean(ScheduledExecutorService.class);
     }
 
@@ -48,23 +49,31 @@ class ScheduledTaskBeanLocator implements ApplicationContextAware {
      */
     private <T> T resolveSchedulerBean(Class<T> schedulerType) {
         try {
-            return resolveSchedulerBean(schedulerType, false);
+            return resolveSchedulerBeanByType(schedulerType);
         } catch (NoUniqueBeanDefinitionException ex) { // multiple beans available, use name
-            return resolveSchedulerBean(schedulerType, true);
+            return resolveSchedulerBeanByName(schedulerType);
         } catch (NoSuchBeanDefinitionException ex2) {
             return null;
         }
     }
 
-    private <T> T resolveSchedulerBean(Class<T> schedulerType, boolean byName) {
-        if (byName) {
-            return this.beanFactory.getBean(DEFAULT_TASK_SCHEDULER_BEAN_NAME, schedulerType);
-        } else if (this.beanFactory instanceof AutowireCapableBeanFactory) {
+    private <T> T resolveSchedulerBeanByType(Class<T> schedulerType) {
+        if (this.beanFactory instanceof AutowireCapableBeanFactory) {
             AutowireCapableBeanFactory factory = (AutowireCapableBeanFactory) this.beanFactory;
             NamedBeanHolder<T> holder = factory.resolveNamedBean(schedulerType);
             return holder.getBeanInstance();
         } else {
             return this.beanFactory.getBean(schedulerType);
+        }
+    }
+
+    private <T> T resolveSchedulerBeanByName(Class<T> schedulerType) {
+        try {
+            return beanFactory.getBean(DEFAULT_TASK_SCHEDULER_BEAN_NAME, schedulerType);
+        } catch (NoSuchBeanDefinitionException exc) {
+            return null;
+        } catch (BeanNotOfRequiredTypeException exc) {
+            return null;
         }
     }
 }

--- a/bugsnag-spring/src/main/java/com/bugsnag/ScheduledTaskBeanLocator.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/ScheduledTaskBeanLocator.java
@@ -1,0 +1,70 @@
+package com.bugsnag;
+
+import static org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor.DEFAULT_TASK_SCHEDULER_BEAN_NAME;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.beans.factory.config.NamedBeanHolder;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+@Configuration
+class ScheduledTaskBeanLocator implements ApplicationContextAware {
+
+    private ApplicationContext beanFactory;
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.beanFactory = applicationContext;
+    }
+
+    public TaskScheduler resolveTaskScheduler() {
+        return resolveSchedulerBean(TaskScheduler.class);
+    }
+
+    public ScheduledExecutorService resolveScheduledExecutorService() {
+        return resolveSchedulerBean(ScheduledExecutorService.class);
+    }
+
+    /**
+     * Resolves a bean, first by searching for any bean in the
+     * {@link org.springframework.beans.factory.BeanFactory}
+     * which matches the type, and then by returning any bean which matches the
+     * given bean name. If no bean can be found which satisifies either of these
+     * conditions, null will be returned.
+     * <p>
+     * This broadly follows the approach used in {@link ScheduledAnnotationBeanPostProcessor}.
+     *
+     * @param schedulerType the scheduler clas
+     * @param <T>           the bean type
+     * @return the resolved bean, or null if it could not be found
+     */
+    private <T> T resolveSchedulerBean(Class<T> schedulerType) {
+        try {
+            return resolveSchedulerBean(schedulerType, false);
+        } catch (NoUniqueBeanDefinitionException ex) { // multiple beans available, use name
+            return resolveSchedulerBean(schedulerType, true);
+        } catch (NoSuchBeanDefinitionException ex2) {
+            return null;
+        }
+    }
+
+    private <T> T resolveSchedulerBean(Class<T> schedulerType, boolean byName) {
+        if (byName) {
+            return this.beanFactory.getBean(DEFAULT_TASK_SCHEDULER_BEAN_NAME, schedulerType);
+        } else if (this.beanFactory instanceof AutowireCapableBeanFactory) {
+            AutowireCapableBeanFactory factory = (AutowireCapableBeanFactory) this.beanFactory;
+            NamedBeanHolder<T> holder = factory.resolveNamedBean(schedulerType);
+            return holder.getBeanInstance();
+        } else {
+            return this.beanFactory.getBean(schedulerType);
+        }
+    }
+}

--- a/bugsnag-spring/src/main/java/com/bugsnag/ScheduledTaskConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/ScheduledTaskConfiguration.java
@@ -6,11 +6,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.springframework.util.ErrorHandler;
 
 import java.lang.reflect.Field;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Add configuration for reporting unhandled exceptions for scheduled tasks.
@@ -23,6 +25,9 @@ class ScheduledTaskConfiguration implements SchedulingConfigurer {
     @Autowired
     private Bugsnag bugsnag;
 
+    @Autowired
+    private ScheduledTaskBeanLocator beanLocator;
+
     /**
      * Add bugsnag error handling to a task scheduler
      */
@@ -31,51 +36,82 @@ class ScheduledTaskConfiguration implements SchedulingConfigurer {
         BugsnagScheduledTaskExceptionHandler bugsnagErrorHandler =
                 new BugsnagScheduledTaskExceptionHandler(bugsnag);
 
-        if (taskRegistrar.getScheduler() == null) {
+        // Decision process for finding a TaskScheduler, in order of preference:
+        //
+        // 1. use the scheduler from the task registrar
+        // 2. search for a TaskScheduler bean, by type, then by name
+        // 3. search for a ScheduledExecutorService bean by type, then by name,
+        //    and wrap it in a TaskScheduler
+        // 4. create our own TaskScheduler
 
-            // If no task scheduler has been defined by the application, create one
-            // and add the bugsnag error handler.
-            ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
-            taskScheduler.setErrorHandler(bugsnagErrorHandler);
-            taskScheduler.initialize();
-            taskRegistrar.setScheduler(taskScheduler);
+        TaskScheduler taskScheduler = resolveExistingTaskScheduler(taskRegistrar);
+
+        if (taskScheduler != null) {
+            configureExistingTaskScheduler(taskScheduler, bugsnagErrorHandler);
         } else {
-
-            // If a task scheduler has been defined by the application, get it so that
-            // bugsnag error handling can be added.
-            TaskScheduler taskScheduler = taskRegistrar.getScheduler();
-
-            // Reflection is the simplest way to get and set an error handler
-            // because the error handler setter is only defined in the concrete classes,
-            // not the TaskScheduler interface.
-            try {
-                Field errorHandlerField =
-                        taskScheduler.getClass().getDeclaredField("errorHandler");
-                errorHandlerField.setAccessible(true);
-                Object existingErrorHandler = errorHandlerField.get(taskScheduler);
-
-                // If an error handler has already been defined then make the Bugsnag handler
-                // call this afterwards
-                if (existingErrorHandler instanceof ErrorHandler) {
-                    bugsnagErrorHandler.setExistingErrorHandler(
-                            (ErrorHandler) existingErrorHandler);
-                }
-
-                // Add the bugsnag error handler to the scheduler.
-                errorHandlerField.set(taskScheduler, bugsnagErrorHandler);
-            } catch (NoSuchFieldException ex) {
-                logScheduledErrorHandlerNotConfigured();
-            } catch (IllegalArgumentException ex) {
-                logScheduledErrorHandlerNotConfigured();
-            } catch (IllegalAccessException ex) {
-                logScheduledErrorHandlerNotConfigured();
-            } catch (SecurityException ex) {
-                logScheduledErrorHandlerNotConfigured();
-            }
+            ScheduledExecutorService executorService
+                    = beanLocator.resolveScheduledExecutorService();
+            taskScheduler = createNewTaskScheduler(executorService, bugsnagErrorHandler);
+            taskRegistrar.setScheduler(taskScheduler);
         }
     }
 
-    private void logScheduledErrorHandlerNotConfigured() {
-        LOGGER.warn("Bugsnag scheduled task exception handler could not be configured");
+    private TaskScheduler resolveExistingTaskScheduler(ScheduledTaskRegistrar taskRegistrar) {
+        TaskScheduler registrarScheduler = taskRegistrar.getScheduler();
+
+        if (registrarScheduler != null) {
+            return registrarScheduler;
+        } else {
+            return beanLocator.resolveTaskScheduler();
+        }
+    }
+
+    private TaskScheduler createNewTaskScheduler(
+            ScheduledExecutorService executorService,
+            BugsnagScheduledTaskExceptionHandler errorHandler) {
+        if (executorService != null) {
+            // create a task scheduler which delegates to the existing Executor
+            ConcurrentTaskScheduler scheduler = new ConcurrentTaskScheduler(executorService);
+            scheduler.setErrorHandler(errorHandler);
+            return scheduler;
+        } else {
+            // If no task scheduler has been defined by the application, create one
+            // and add the bugsnag error handler.
+            ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+            scheduler.setErrorHandler(errorHandler);
+            scheduler.initialize();
+            return scheduler;
+        }
+    }
+
+    /**
+     * If a task scheduler has been defined by the application, get it so that
+     * bugsnag error handling can be added.
+     * <p>
+     * Reflection is the simplest way to get and set an error handler
+     * because the error handler setter is only defined in the concrete classes,
+     * not the TaskScheduler interface.
+     *
+     * @param taskScheduler the task scheduler
+     */
+    private void configureExistingTaskScheduler(TaskScheduler taskScheduler,
+                                                BugsnagScheduledTaskExceptionHandler errorHandler) {
+        try {
+            Field errorHandlerField =
+                    taskScheduler.getClass().getDeclaredField("errorHandler");
+            errorHandlerField.setAccessible(true);
+            Object existingErrorHandler = errorHandlerField.get(taskScheduler);
+
+            // If an error handler has already been defined then make the Bugsnag handler
+            // call this afterwards
+            if (existingErrorHandler instanceof ErrorHandler) {
+                errorHandler.setExistingErrorHandler((ErrorHandler) existingErrorHandler);
+            }
+
+            // Add the bugsnag error handler to the scheduler.
+            errorHandlerField.set(taskScheduler, errorHandler);
+        } catch (Throwable ex) {
+            LOGGER.warn("Bugsnag scheduled task exception handler could not be configured");
+        }
     }
 }

--- a/bugsnag-spring/src/main/java/com/bugsnag/ScheduledTaskConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/ScheduledTaskConfiguration.java
@@ -44,7 +44,9 @@ class ScheduledTaskConfiguration implements SchedulingConfigurer {
         //    and wrap it in a TaskScheduler
         // 4. create our own TaskScheduler
 
-        TaskScheduler taskScheduler = resolveExistingTaskScheduler(taskRegistrar);
+        TaskScheduler registrarScheduler = taskRegistrar.getScheduler();
+        TaskScheduler taskScheduler = registrarScheduler != null
+                ? registrarScheduler : beanLocator.resolveTaskScheduler();
 
         if (taskScheduler != null) {
             configureExistingTaskScheduler(taskScheduler, bugsnagErrorHandler);
@@ -53,16 +55,6 @@ class ScheduledTaskConfiguration implements SchedulingConfigurer {
                     = beanLocator.resolveScheduledExecutorService();
             taskScheduler = createNewTaskScheduler(executorService, bugsnagErrorHandler);
             taskRegistrar.setScheduler(taskScheduler);
-        }
-    }
-
-    private TaskScheduler resolveExistingTaskScheduler(ScheduledTaskRegistrar taskRegistrar) {
-        TaskScheduler registrarScheduler = taskRegistrar.getScheduler();
-
-        if (registrarScheduler != null) {
-            return registrarScheduler;
-        } else {
-            return beanLocator.resolveTaskScheduler();
         }
     }
 

--- a/bugsnag-spring/src/test/java/com/bugsnag/ScheduledTaskBeanLocatorTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/ScheduledTaskBeanLocatorTest.java
@@ -1,0 +1,82 @@
+package com.bugsnag;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+import com.bugsnag.testapp.springboot.TestSpringBootApplication;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestSpringBootApplication.class)
+public class ScheduledTaskBeanLocatorTest {
+
+    @Autowired
+    private ScheduledTaskBeanLocator beanLocator;
+
+    @MockBean
+    private ApplicationContext context;
+
+    @Before
+    public void setUp() {
+        beanLocator.setApplicationContext(context);
+    }
+
+    @Test
+    public void findSchedulerByType() {
+        ThreadPoolTaskScheduler expected = new ThreadPoolTaskScheduler();
+        when(context.getBean(TaskScheduler.class)).thenReturn(expected);
+        assertEquals(expected, beanLocator.resolveTaskScheduler());
+    }
+
+    @Test
+    public void findSchedulerByName() {
+        ThreadPoolTaskScheduler expected = new ThreadPoolTaskScheduler();
+        Throwable exc = new NoUniqueBeanDefinitionException(TaskScheduler.class);
+        when(context.getBean(TaskScheduler.class)).thenThrow(exc);
+        when(context.getBean("taskScheduler", TaskScheduler.class)).thenReturn(expected);
+        assertEquals(expected, beanLocator.resolveTaskScheduler());
+    }
+
+    @Test
+    public void noTaskSchedulerAvailable() {
+        assertNull(beanLocator.resolveTaskScheduler());
+    }
+
+    @Test
+    public void findExecutorByType() {
+        ScheduledExecutorService expected = Executors.newScheduledThreadPool(1);
+        when(context.getBean(ScheduledExecutorService.class)).thenReturn(expected);
+        assertEquals(expected, beanLocator.resolveScheduledExecutorService());
+    }
+
+    @Test
+    public void findExecutorByName() {
+        ScheduledExecutorService expected = Executors.newScheduledThreadPool(4);
+        Throwable exc = new NoUniqueBeanDefinitionException(ScheduledExecutorService.class);
+        when(context.getBean(ScheduledExecutorService.class)).thenThrow(exc);
+        when(context.getBean("taskScheduler", ScheduledExecutorService.class))
+                .thenReturn(expected);
+        assertEquals(expected, beanLocator.resolveScheduledExecutorService());
+    }
+
+    @Test
+    public void noScheduledExecutorAvailable() {
+        assertNull(beanLocator.resolveScheduledExecutorService());
+    }
+}

--- a/bugsnag-spring/src/test/java/com/bugsnag/ScheduledTaskConfigurationTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/ScheduledTaskConfigurationTest.java
@@ -1,0 +1,122 @@
+package com.bugsnag;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.bugsnag.testapp.springboot.TestSpringBootApplication;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.mockito.Mock;
+
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestSpringBootApplication.class)
+public class ScheduledTaskConfigurationTest {
+
+    @Autowired
+    private ScheduledTaskConfiguration configuration;
+
+    @Mock
+    private ScheduledTaskRegistrar registrar;
+
+    @Autowired
+    private ScheduledTaskBeanLocator beanLocator;
+
+    @MockBean
+    private ApplicationContext context;
+
+    @Before
+    public void setUp() {
+        registrar = new ScheduledTaskRegistrar();
+        beanLocator.setApplicationContext(context);
+    }
+
+    @Test
+    public void existingSchedulerUsed() {
+        ThreadPoolTaskScheduler expected = new ThreadPoolTaskScheduler();
+        registrar.setScheduler(expected);
+        configuration.configureTasks(registrar);
+        assertEquals(expected, registrar.getScheduler());
+    }
+
+    @Test
+    public void noSchedulersAvailable() {
+        configuration.configureTasks(registrar);
+        assertTrue(registrar.getScheduler() instanceof ThreadPoolTaskScheduler);
+    }
+
+    @Test
+    public void findSchedulerByType() throws NoSuchFieldException, IllegalAccessException {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        when(context.getBean(TaskScheduler.class)).thenReturn(scheduler);
+
+        configuration.configureTasks(registrar);
+        assertNull(registrar.getScheduler());
+        Object errorHandler = accessField(scheduler, "errorHandler");
+        assertTrue(errorHandler instanceof BugsnagScheduledTaskExceptionHandler);
+    }
+
+    @Test
+    public void findSchedulerByName() throws NoSuchFieldException, IllegalAccessException {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        Throwable exc = new NoUniqueBeanDefinitionException(TaskScheduler.class);
+        when(context.getBean(TaskScheduler.class)).thenThrow(exc);
+        when(context.getBean("taskScheduler", TaskScheduler.class)).thenReturn(scheduler);
+
+        configuration.configureTasks(registrar);
+        assertNull(registrar.getScheduler());
+        Object errorHandler = accessField(scheduler, "errorHandler");
+        assertTrue(errorHandler instanceof BugsnagScheduledTaskExceptionHandler);
+    }
+
+    @Test
+    public void findExecutorByType() throws NoSuchFieldException, IllegalAccessException {
+        ScheduledExecutorService expected = Executors.newScheduledThreadPool(1);
+        when(context.getBean(ScheduledExecutorService.class)).thenReturn(expected);
+
+        configuration.configureTasks(registrar);
+        TaskScheduler scheduler = registrar.getScheduler();
+        assertTrue(scheduler instanceof ConcurrentTaskScheduler);
+        assertEquals(expected, accessField(scheduler, "scheduledExecutor"));
+    }
+
+    @Test
+    public void findExecutorByName() throws NoSuchFieldException, IllegalAccessException {
+        ScheduledExecutorService expected = Executors.newScheduledThreadPool(4);
+        Throwable exc = new NoUniqueBeanDefinitionException(ScheduledExecutorService.class);
+        when(context.getBean(ScheduledExecutorService.class)).thenThrow(exc);
+        when(context.getBean("taskScheduler", ScheduledExecutorService.class))
+                .thenReturn(expected);
+
+        configuration.configureTasks(registrar);
+        TaskScheduler scheduler = registrar.getScheduler();
+        assertTrue(scheduler instanceof ConcurrentTaskScheduler);
+        assertEquals(expected, accessField(scheduler, "scheduledExecutor"));
+    }
+
+    private Object accessField(Object object, String fieldName)
+            throws NoSuchFieldException, IllegalAccessException {
+        Field field = object.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(object);
+    }
+}

--- a/features/fixtures/mazerunnerspringboot/src/main/java/com/bugsnag/mazerunner/scenarios/ScheduledTaskExecutorScenario.java
+++ b/features/fixtures/mazerunnerspringboot/src/main/java/com/bugsnag/mazerunner/scenarios/ScheduledTaskExecutorScenario.java
@@ -1,0 +1,36 @@
+package com.bugsnag.mazerunner.scenarios;
+
+import com.bugsnag.Bugsnag;
+import com.bugsnag.Report;
+import com.bugsnag.callbacks.Callback;
+import com.bugsnag.mazerunnerspringboot.ScheduledTaskExecutorService;
+import java.util.Collection;
+
+public class ScheduledTaskExecutorScenario extends Scenario {
+
+    public ScheduledTaskExecutorScenario(Bugsnag bugsnag) {
+        super(bugsnag);
+    }
+
+    @Override
+    public void run() {
+        // Enable throwing an exception in the scheduled task
+        ScheduledTaskExecutorService.setSendException();
+
+        // Wait for the exception
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException ex) {
+            // ignore
+        }
+
+        final Collection<String> threadnames = ScheduledTaskExecutorService.getThreadNames();
+        bugsnag.notify(new RuntimeException("Whoops"), new Callback() {
+            @Override
+            public void beforeNotify(Report report) {
+                report.addToTab("executor", "multiThreaded", threadnames.size() > 1);
+                report.addToTab("executor", "names", threadnames);
+            }
+        });
+    }
+}

--- a/features/fixtures/mazerunnerspringboot/src/main/java/com/bugsnag/mazerunnerspringboot/ScheduledTaskConfig.java
+++ b/features/fixtures/mazerunnerspringboot/src/main/java/com/bugsnag/mazerunnerspringboot/ScheduledTaskConfig.java
@@ -1,0 +1,36 @@
+package com.bugsnag.mazerunnerspringboot;
+
+import com.bugsnag.Bugsnag;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+@Configuration
+@EnableScheduling
+public class ScheduledTaskConfig {
+
+    @ConditionalOnProperty(name = "scheduled_executor_service_bean", havingValue = "true")
+    @Bean
+    public Executor taskScheduler() {
+        return Executors.newScheduledThreadPool(4);
+    }
+
+    @ConditionalOnProperty(name = "other_scheduled_executor_service_bean", havingValue = "true")
+    @Bean
+    public Executor otherTaskScheduler() {
+        return Executors.newScheduledThreadPool(4);
+    }
+
+    @ConditionalOnProperty(name = "custom_task_scheduler_bean", havingValue = "true")
+    @Bean
+    public TaskScheduler customTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(4);
+        return scheduler;
+    }
+}

--- a/features/fixtures/mazerunnerspringboot/src/main/java/com/bugsnag/mazerunnerspringboot/ScheduledTaskConfig.java
+++ b/features/fixtures/mazerunnerspringboot/src/main/java/com/bugsnag/mazerunnerspringboot/ScheduledTaskConfig.java
@@ -33,4 +33,12 @@ public class ScheduledTaskConfig {
         scheduler.setPoolSize(4);
         return scheduler;
     }
+
+    @ConditionalOnProperty(name = "second_task_scheduler_bean", havingValue = "true")
+    @Bean(name = "taskScheduler")
+    public TaskScheduler secondTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(2);
+        return scheduler;
+    }
 }

--- a/features/fixtures/mazerunnerspringboot/src/main/java/com/bugsnag/mazerunnerspringboot/ScheduledTaskConfig.java
+++ b/features/fixtures/mazerunnerspringboot/src/main/java/com/bugsnag/mazerunnerspringboot/ScheduledTaskConfig.java
@@ -23,7 +23,7 @@ public class ScheduledTaskConfig {
     @ConditionalOnProperty(name = "other_scheduled_executor_service_bean", havingValue = "true")
     @Bean
     public Executor otherTaskScheduler() {
-        return Executors.newScheduledThreadPool(4);
+        return Executors.newScheduledThreadPool(2);
     }
 
     @ConditionalOnProperty(name = "custom_task_scheduler_bean", havingValue = "true")

--- a/features/fixtures/mazerunnerspringboot/src/main/java/com/bugsnag/mazerunnerspringboot/ScheduledTaskExecutorService.java
+++ b/features/fixtures/mazerunnerspringboot/src/main/java/com/bugsnag/mazerunnerspringboot/ScheduledTaskExecutorService.java
@@ -1,0 +1,41 @@
+package com.bugsnag.mazerunnerspringboot;
+
+import com.bugsnag.Bugsnag;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Autowired;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Collection;
+
+@Service
+public class ScheduledTaskExecutorService {
+
+    @Autowired
+    private Bugsnag bugsnag;
+
+    private final Set<String> threadNames = new HashSet<String>();
+
+    private volatile boolean sendException = false;
+
+    private static ScheduledTaskExecutorService instance;
+
+    public ScheduledTaskExecutorService() {
+        instance = this;
+    }
+
+    public static void setSendException() {
+        instance.sendException = true;
+    }
+
+    public static Collection<String> getThreadNames() {
+        return new HashSet<>(instance.threadNames);
+    }
+
+    @Scheduled(fixedRate = 100)
+    public void doSomething() {
+        if (sendException) {
+            threadNames.add(Thread.currentThread().getName());
+        }
+    }
+}

--- a/features/scheduled_task_executor.feature
+++ b/features/scheduled_task_executor.feature
@@ -28,6 +28,14 @@ Scenario: For multiple ScheduledExecutorService beans, the one named "taskSchedu
     And the request is a valid for the error reporting API
     And the exception "message" equals "Unhandled exception from ScheduledTaskService"
 
+Scenario: For multiple ScheduledExecutorService beans, the one named "taskScheduler" is used
+    Given I set environment variable "custom_task_scheduler_bean" to "true"
+    Given I set environment variable "second_task_scheduler_bean" to "true"
+    And I run spring boot "ScheduledTaskScenario" with the defaults
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the exception "message" equals "Unhandled exception from ScheduledTaskService"
+
 Scenario: Scheduled tasks execute on a ScheduledExecutorService rather than a single-threaded Executor, when available
     Given I set environment variable "scheduled_executor_service_bean" to "true"
     And I run spring boot "ScheduledTaskExecutorScenario" with the defaults

--- a/features/scheduled_task_executor.feature
+++ b/features/scheduled_task_executor.feature
@@ -1,0 +1,29 @@
+Feature: Verifies that unhandled exceptions in scheduled tasks are reported to Bugsnag regardless of Scheduler configuration
+
+Scenario: By default a single-threaded ThreadPoolTaskScheduler is used
+    When I run spring boot "ScheduledTaskScenario" with the defaults
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the exception "message" equals "Unhandled exception from ScheduledTaskService"
+
+Scenario: A TaskScheduler supplied as a bean is used
+    Given I set environment variable "custom_task_scheduler_bean" to "true"
+    And I run spring boot "ScheduledTaskScenario" with the defaults
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the exception "message" equals "Unhandled exception from ScheduledTaskService"
+
+Scenario: A ScheduledExecutorService supplied as a bean is used
+    Given I set environment variable "scheduled_executor_service_bean" to "true"
+    And I run spring boot "ScheduledTaskScenario" with the defaults
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the exception "message" equals "Unhandled exception from ScheduledTaskService"
+
+Scenario: For multiple ScheduledExecutorService beans, the one named "taskScheduler" is used
+    Given I set environment variable "scheduled_executor_service_bean" to "true"
+    And I set environment variable "other_scheduled_executor_service_bean" to "true"
+    And I run spring boot "ScheduledTaskScenario" with the defaults
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the exception "message" equals "Unhandled exception from ScheduledTaskService"

--- a/features/scheduled_task_executor.feature
+++ b/features/scheduled_task_executor.feature
@@ -28,7 +28,7 @@ Scenario: For multiple ScheduledExecutorService beans, the one named "taskSchedu
     And the request is a valid for the error reporting API
     And the exception "message" equals "Unhandled exception from ScheduledTaskService"
 
-Scenario: For multiple ScheduledExecutorService beans, the one named "taskScheduler" is used
+Scenario: For multiple TaskScheduler beans, the one named "taskScheduler" is used
     Given I set environment variable "custom_task_scheduler_bean" to "true"
     Given I set environment variable "second_task_scheduler_bean" to "true"
     And I run spring boot "ScheduledTaskScenario" with the defaults

--- a/features/scheduled_task_executor.feature
+++ b/features/scheduled_task_executor.feature
@@ -27,3 +27,10 @@ Scenario: For multiple ScheduledExecutorService beans, the one named "taskSchedu
     Then I should receive a request
     And the request is a valid for the error reporting API
     And the exception "message" equals "Unhandled exception from ScheduledTaskService"
+
+Scenario: Scheduled tasks execute on a ScheduledExecutorService rather than a single-threaded Executor, when available
+    Given I set environment variable "scheduled_executor_service_bean" to "true"
+    And I run spring boot "ScheduledTaskExecutorScenario" with the defaults
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the event "metaData.executor.multiThreaded" is true


### PR DESCRIPTION
## Goal

The Spring Notifier sets an `ErrorHandler` on the application's [`TaskScheduler`](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/scheduling/TaskScheduler.html), which is required to capture unhandled exceptions that occur in [scheduled tasks](https://spring.io/guides/gs/scheduling-tasks/). This is configured via a [`SchedulingConfigurer`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/annotation/SchedulingConfigurer.html) which is invoked on application startup.

Previously the notifier assumed that if the `taskRegistrar.getScheduler()` returned null, then no `TaskScheduler` was configured. The notifier therefore set a custom `TaskScheduler` with a bugsnag error handler, and a single-threaded `Executor`. However, this misses two alternative methods for configuring a scheduler that Spring provides:

1. exposing a `TaskScheduler` bean
2. exposing a `ScheduledExecutorService` bean

This led to a scenario where an application defined an `Executor` with a thread pool of 4, which was reset to a thread pool of 1 when bugsnag-spring was included, which meant the scheduled tasks did not run successfully.

This proposed changeset alters the notifier to handle these two cases.

## Changeset

This changeset is currently delivered in 3 separate commits, which are easiest to review in isolation:

1. Add mazerunner coverage for unhandled exceptions in scheduled tasks, where the `TaskScheduler` has been configured in different ways: https://github.com/bugsnag/bugsnag-java/commit/88ceab29ffe60df7f9f50b2dd008643ed8c39b54

2. Resolve the `TaskScheduler` and `ScheduledExecutorService` beans in the default `BeanFactory`: https://github.com/bugsnag/bugsnag-java/commit/feb849f300523132a0ff2246b668318e6225cb14

3. Fix `ScheduledTaskConfiguration` to search for beans before overriding the `TaskScheduler`: https://github.com/bugsnag/bugsnag-java/commit/f3456773930a3fb921937fb30f61e5f6eccd5749

## Tests

New mazerunner and unit tests have been added, as described above.

Additionally, I have manually tested an example app to ensure that defining `TaskScheduler` and `ScheduledExecutorService` beans results in them being set as the `TaskScheduler` in the `ScheduledTaskConfiguration` class.
