### PR TITLE
Allow sources to be published to mavenLocal()

### DIFF
--- a/release.gradle
+++ b/release.gradle
@@ -49,6 +49,10 @@ modifyPom {
     }
 }
 
+task sourceJar(type: Jar) {
+    from sourceSets.main.allJava
+}
+
 publishing {
     publications {
         Publication(MavenPublication) {
@@ -56,6 +60,9 @@ publishing {
             groupId 'com.bugsnag'
             artifactId project.findProperty('artifactId')
             version rootProject.version
+            artifact sourceJar {
+                classifier "sources"
+            }
         }
     }
 }


### PR DESCRIPTION
## Goal

Allow a sources jar to be published to the local maven repository along with the library jar when executing `./gradlew publishToMavenLocal` which is useful for local testing and debugging.