### PR TITLE
Remove unnecessary @Configuration annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.4.4 (2019-01-15)
+
+* Remove unnecessary `@Configuration` annotation
+  [#130](https://github.com/bugsnag/bugsnag-java/pull/130)
+
 ## 3.4.3 (2019-01-07)
 
 * Support other methods of configuring a TaskScheduler when setting ErrorHandler on scheduled tasks

--- a/bugsnag-spring/src/main/java/com/bugsnag/ScheduledTaskBeanLocator.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/ScheduledTaskBeanLocator.java
@@ -10,13 +10,11 @@ import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.beans.factory.config.NamedBeanHolder;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
 
 import java.util.concurrent.ScheduledExecutorService;
 
-@Configuration
 class ScheduledTaskBeanLocator implements ApplicationContextAware {
 
     private ApplicationContext beanFactory;

--- a/bugsnag/src/main/java/com/bugsnag/Notifier.java
+++ b/bugsnag/src/main/java/com/bugsnag/Notifier.java
@@ -5,7 +5,7 @@ import com.bugsnag.serialization.Expose;
 class Notifier {
 
     private static final String NOTIFIER_NAME = "Bugsnag Java";
-    private static final String NOTIFIER_VERSION = "3.4.3";
+    private static final String NOTIFIER_VERSION = "3.4.4";
     private static final String NOTIFIER_URL = "https://github.com/bugsnag/bugsnag-java";
 
     private String notifierName = NOTIFIER_NAME;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=3.4.3
+version=3.4.4
 group=com.bugsnag
 
 # Default properties


### PR DESCRIPTION
## Goal

Remove the `@Configuration` annotation from `ScheduledTaskBeanLocator` which would prevent an application from starting if the class was imported into an application because a bean of that type is already explicitly defined in `BugsnagSpringConfiguration`.

## Review

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
