### PR TITLE
Migrate non-standard device fields to metaData.device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.X.X (TBD)
+
+* Migrate non-standard device fields to metaData.device
+  [#131](https://github.com/bugsnag/bugsnag-java/pull/131)
+
 ## 3.4.3 (2019-01-07)
 
 * Support other methods of configuring a TaskScheduler when setting ErrorHandler on scheduled tasks

--- a/bugsnag/src/main/java/com/bugsnag/Report.java
+++ b/bugsnag/src/main/java/com/bugsnag/Report.java
@@ -209,7 +209,9 @@ public class Report {
      * @param key   the key of app info to add
      * @param value the value of app info to add
      * @return the modified report
+     * @deprecated use {@link #addToTab(String, String, Object)} instead
      */
+    @Deprecated
     public Report setAppInfo(String key, Object value) {
         diagnostics.app.put(key, value);
         return this;
@@ -252,7 +254,9 @@ public class Report {
      * @param key   the key of device info to add
      * @param value the value of device info to add
      * @return the modified report
+     * @deprecated use {@link #addToTab(String, String, Object)} instead
      */
+    @Deprecated
     public Report setDeviceInfo(String key, Object value) {
         diagnostics.device.put(key, value);
         return this;

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
@@ -55,12 +55,12 @@ public class DeviceCallback implements Callback {
     @Override
     public void beforeNotify(Report report) {
         report
+                .addToTab("device", "osArch", System.getProperty("os.arch"))
+                .addToTab("device", "runtimeName", System.getProperty("java.runtime.name"))
+                .addToTab("device", "runtimeVersion", System.getProperty("java.runtime.version"))
+                .addToTab("device", "locale", Locale.getDefault())
                 .setDeviceInfo("hostname", getHostnameValue())
                 .setDeviceInfo("osName", System.getProperty("os.name"))
-                .setDeviceInfo("osVersion", System.getProperty("os.version"))
-                .setDeviceInfo("osArch", System.getProperty("os.arch"))
-                .setDeviceInfo("runtimeName", System.getProperty("java.runtime.name"))
-                .setDeviceInfo("runtimeVersion", System.getProperty("java.runtime.version"))
-                .setDeviceInfo("locale", Locale.getDefault());
+                .setDeviceInfo("osVersion", System.getProperty("os.version"));
     }
 }


### PR DESCRIPTION
## Goal

Migrates non-standard device fields which are not specified in our [Error API docs](https://bugsnagerrorreportingapi.docs.apiary.io/#reference/0/notify/send-error-reports) to `metaData.device` instead.

## Design


## Changeset

- Migrated `osArch`, `runtimeName`, `runtimeVersion`, and `locale` to `metaData.device`.
- Deprecated `report.setAppInfo` and `report.setDeviceInfo` in favour of `report.addToTab`

## Tests

Ran existing tests on CI, inspected payload manually to confirm that the JSON appears as expected, and confirmed that each field still shows on handled/unhandled errors in the dashboard.
