### PR TITLE
Upgrade checkstyle version + fix example imports

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -3,7 +3,9 @@ ext {
     logbackVersion = "1.2.3"
 }
 
-apply plugin: 'checkstyle'
+if (JavaVersion.current().isJava8Compatible()) {
+    apply plugin: 'checkstyle'
+}
 
 if (project.hasProperty('releasing')) {
     apply from: "../release.gradle"
@@ -18,7 +20,9 @@ test {
     }
 }
 
-checkstyle {
-    toolVersion = "8.18"
-    configFile = new File(rootDir, "config/checkstyle/checkstyle.xml")
+if (JavaVersion.current().isJava8Compatible()) {
+    checkstyle {
+        toolVersion = "8.18"
+        configFile = new File(rootDir, "config/checkstyle/checkstyle.xml")
+    }
 }

--- a/common.gradle
+++ b/common.gradle
@@ -19,6 +19,6 @@ test {
 }
 
 checkstyle {
-    toolVersion = "6.16"
+    toolVersion = "8.18"
     configFile = new File(rootDir, "config/checkstyle/checkstyle.xml")
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -49,9 +49,7 @@
             <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
         <module name="NeedBraces"/>
-        <module name="LeftCurly">
-            <property name="maxLineLength" value="100"/>
-        </module>
+        <module name="LeftCurly"/>
         <module name="RightCurly"/>
         <module name="RightCurly">
             <property name="option" value="alone"/>

--- a/examples/logback/src/main/java/com/bugsnag/example/logback/cli/Application.java
+++ b/examples/logback/src/main/java/com/bugsnag/example/logback/cli/Application.java
@@ -1,12 +1,12 @@
 package com.bugsnag.example.logback.cli;
 
-import ch.qos.logback.core.Appender;
 import com.bugsnag.Bugsnag;
 import com.bugsnag.BugsnagAppender;
 import com.bugsnag.logback.BugsnagMarker;
+
+import ch.qos.logback.core.Appender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.Marker;
 
 import java.util.Date;
 

--- a/examples/servlet/src/main/java/com/bugsnag/example/servlet/ExampleServlet.java
+++ b/examples/servlet/src/main/java/com/bugsnag/example/servlet/ExampleServlet.java
@@ -7,7 +7,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
 public class ExampleServlet extends HttpServlet {
 
@@ -24,7 +23,7 @@ public class ExampleServlet extends HttpServlet {
     }
 
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException {
         // Send a handled exception to Bugsnag
         try {
             throw new RuntimeException("Handled exception - default severity");

--- a/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/ApplicationRestController.java
+++ b/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/ApplicationRestController.java
@@ -4,6 +4,7 @@ import com.bugsnag.Bugsnag;
 import com.bugsnag.Report;
 import com.bugsnag.Severity;
 import com.bugsnag.callbacks.Callback;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Config.java
+++ b/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Config.java
@@ -4,6 +4,7 @@ import com.bugsnag.Bugsnag;
 import com.bugsnag.BugsnagSpringConfiguration;
 import com.bugsnag.Report;
 import com.bugsnag.callbacks.Callback;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;

--- a/examples/spring/src/main/java/com/bugsnag/example/spring/cli/ApplicationCommandLineRunner.java
+++ b/examples/spring/src/main/java/com/bugsnag/example/spring/cli/ApplicationCommandLineRunner.java
@@ -4,6 +4,7 @@ import com.bugsnag.Bugsnag;
 import com.bugsnag.Report;
 import com.bugsnag.Severity;
 import com.bugsnag.callbacks.Callback;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Config.java
+++ b/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Config.java
@@ -4,6 +4,7 @@ import com.bugsnag.Bugsnag;
 import com.bugsnag.BugsnagSpringConfiguration;
 import com.bugsnag.Report;
 import com.bugsnag.callbacks.Callback;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ include ':bugsnag',
         ':bugsnag-spring'
 
 // Exclude examples from JDK7 build as they are written for JDK8
-if(JavaVersion.current().isJava8Compatible()){
+if (JavaVersion.current().isJava8Compatible()) {
     include ':examples:simple',
             ':examples:servlet',
             ':examples:spring',


### PR DESCRIPTION
Upgrade checkstyle version to latest, 8.18, including removing a field from the checkstyle config that is no longer part of the schema. 

Also, tidy up import statements in the example projects.