### PR TITLE
Fix build warnings

### DIFF
--- a/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
@@ -1,13 +1,13 @@
 package com.bugsnag;
 
+import static com.bugsnag.TestUtils.anyMapOf;
 import static com.bugsnag.TestUtils.verifyAndGetReport;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/bugsnag-spring/src/test/java/com/bugsnag/TestUtils.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/TestUtils.java
@@ -1,7 +1,6 @@
 package com.bugsnag;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
@@ -9,6 +8,9 @@ import com.bugsnag.delivery.Delivery;
 import com.bugsnag.serialization.Serializer;
 
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+
+import java.util.Map;
 
 class TestUtils {
 
@@ -23,5 +25,13 @@ class TestUtils {
                 notificationCaptor.capture(),
                 anyMapOf(String.class, String.class));
         return notificationCaptor.getValue().getEvents().get(0);
+    }
+
+    /**
+     * {@link ArgumentMatchers#anyMapOf} is deprecated but we still need it for JDK 7 builds
+     */
+    @SuppressWarnings("deprecation")
+    static <K, V> Map<K, V> anyMapOf(Class<K> keyClazz, Class<V> valueClazz) {
+        return ArgumentMatchers.anyMapOf(keyClazz, valueClazz);
     }
 }

--- a/bugsnag/src/main/java/com/bugsnag/logback/BugsnagMarker.java
+++ b/bugsnag/src/main/java/com/bugsnag/logback/BugsnagMarker.java
@@ -44,6 +44,9 @@ public class BugsnagMarker implements Marker {
         return references.remove(reference);
     }
 
+    /**
+     * @deprecated Replaced by {@link #hasReferences()}.
+     */
     @Override
     public boolean hasChildren() {
         return hasReferences();

--- a/bugsnag/src/main/java/com/bugsnag/logback/BugsnagMarker.java
+++ b/bugsnag/src/main/java/com/bugsnag/logback/BugsnagMarker.java
@@ -47,6 +47,7 @@ public class BugsnagMarker implements Marker {
     /**
      * @deprecated Replaced by {@link #hasReferences()}.
      */
+    @Deprecated
     @Override
     public boolean hasChildren() {
         return hasReferences();

--- a/bugsnag/src/test/java/com/bugsnag/MarkerTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/MarkerTest.java
@@ -53,13 +53,19 @@ public class MarkerTest {
     public void testMarkerAddReference() {
 
         assertFalse(marker.hasReferences());
-        assertFalse(marker.hasChildren());
+
+        @SuppressWarnings("deprecation")
+        boolean hasChildrenBefore = marker.hasChildren();
+        assertFalse(hasChildrenBefore);
 
         Marker newMarker = new BugsnagMarker(callback);
         marker.add(newMarker);
 
+        @SuppressWarnings("deprecation")
+        boolean hasChildrenAfter = marker.hasChildren();
+        assertTrue(hasChildrenAfter);
+
         assertTrue(marker.hasReferences());
-        assertTrue(marker.hasChildren());
         assertTrue(marker.contains(newMarker));
         assertTrue(marker.contains(newMarker.getName()));
 
@@ -75,11 +81,17 @@ public class MarkerTest {
         marker.add(newMarker);
 
         assertTrue(marker.hasReferences());
-        assertTrue(marker.hasChildren());
+
+        @SuppressWarnings("deprecation")
+        boolean hasChildrenBefore = marker.hasChildren();
+        assertTrue(hasChildrenBefore);
 
         marker.remove(newMarker);
 
         assertFalse(marker.hasReferences());
-        assertFalse(marker.hasChildren());
+
+        @SuppressWarnings("deprecation")
+        boolean hasChildrenAfter = marker.hasChildren();
+        assertFalse(hasChildrenAfter);
     }
 }


### PR DESCRIPTION
Workarounds for deprecation build warnings for `anymapof` and a deprecated method in `Marker` that we override. 