### PR TITLE
Set thread name to aid debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Migrate non-standard device fields to metaData.device
   [#131](https://github.com/bugsnag/bugsnag-java/pull/131)
 
+* Set thread name to aid debugging
+  [#138](https://github.com/bugsnag/bugsnag-java/pull/138)
+
 ## 3.4.3 (2019-01-07)
 
 * Support other methods of configuring a TaskScheduler when setting ErrorHandler on scheduled tasks

--- a/bugsnag/src/main/java/com/bugsnag/util/DaemonThreadFactory.java
+++ b/bugsnag/src/main/java/com/bugsnag/util/DaemonThreadFactory.java
@@ -21,6 +21,7 @@ public class DaemonThreadFactory implements ThreadFactory {
     @Override
     public Thread newThread(Runnable runner) {
         Thread daemonThread = defaultThreadFactory.newThread(runner);
+        daemonThread.setName("bugsnag-daemon-" + daemonThread.getId());
 
         // Set the threads to daemon to allow the app to shutdown properly
         if (!daemonThread.isDaemon()) {


### PR DESCRIPTION
## Goal
Users have requested that we set the thread name in order to aid debugging.

## Changeset
Used a default thread factory and set the name on the created thread, throughout the bugsnag-java codebase.

## Tests
Manually ran the example app and inspected the thread names in the debugger.

