### PR TITLE
Swallow Throwables thrown when configuring bugsnag appender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.X.X (TBD)
+
+* Swallow Throwables thrown when configuring bugsnag appender
+  [#140](https://github.com/bugsnag/bugsnag-java/pull/140)
+
 ## 3.4.5 (2019-04-04)
 
 * Migrate non-standard device fields to metaData.device

--- a/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
@@ -2,7 +2,6 @@ package com.bugsnag;
 
 import com.bugsnag.callbacks.Callback;
 
-import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
@@ -48,21 +48,25 @@ public class BugsnagSpringConfiguration {
      * messages as they effectively duplicate error reports for unhandled exceptions.
      */
     @PostConstruct
+    @SuppressWarnings("checkstyle:emptycatchblock")
     void excludeLoggers() {
-        // Exclude Tomcat logger when processing HTTP requests via a servlet.
-        // Regex specified to match the servlet variable parts of the logger name, e.g.
-        // the Spring Boot default is:
-        // [Tomcat].[localhost].[/].[dispatcherServlet]
-        // but could be something like:
-        // [Tomcat-1].[127.0.0.1].[/subdomain/].[customDispatcher]
-        BugsnagAppender.addExcludedLoggerPattern("org.apache.catalina.core.ContainerBase."
-                + "\\[Tomcat.*\\][.]\\[.*\\][.]\\[/.*\\][.]\\[.*\\]");
+        try {
+            // Exclude Tomcat logger when processing HTTP requests via a servlet.
+            // Regex specified to match the servlet variable parts of the logger name, e.g.
+            // the Spring Boot default is:
+            // [Tomcat].[localhost].[/].[dispatcherServlet]
+            // but could be something like:
+            // [Tomcat-1].[127.0.0.1].[/subdomain/].[customDispatcher]
+            BugsnagAppender.addExcludedLoggerPattern("org.apache.catalina.core.ContainerBase."
+                    + "\\[Tomcat.*\\][.]\\[.*\\][.]\\[/.*\\][.]\\[.*\\]");
 
-        // Exclude Jetty logger when processing HTTP requests via the HttpChannel
-        BugsnagAppender.addExcludedLoggerPattern("org.eclipse.jetty.server.HttpChannel");
+            // Exclude Jetty logger when processing HTTP requests via the HttpChannel
+            BugsnagAppender.addExcludedLoggerPattern("org.eclipse.jetty.server.HttpChannel");
 
-        // Exclude Undertow logger when processing HTTP requests
-        BugsnagAppender.addExcludedLoggerPattern("io.undertow.request");
+            // Exclude Undertow logger when processing HTTP requests
+            BugsnagAppender.addExcludedLoggerPattern("io.undertow.request");
+        } catch (Throwable ignored) {
+        }
     }
 
 }

--- a/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
@@ -2,6 +2,7 @@ package com.bugsnag;
 
 import com.bugsnag.callbacks.Callback;
 
+import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -65,7 +66,8 @@ public class BugsnagSpringConfiguration {
 
             // Exclude Undertow logger when processing HTTP requests
             BugsnagAppender.addExcludedLoggerPattern("io.undertow.request");
-        } catch (Throwable ignored) {
+        } catch (NoClassDefFoundError ignored) {
+            // logback was not in classpath, ignore throwable to allow further initialisation
         }
     }
 


### PR DESCRIPTION
## Goal
Not all users use Logback in their project, so `BugsnagSpringConfiguration` calling `BugsnagAppender` methods can throw a `NoClassDefFoundError`, as observed in #132. If the dependency is not on the classpath, we should ignore this error and continue initialising bugsnag as normal.

## Tests
Ran the example app with [logback excluded](https://github.com/bugsnag/bugsnag-java/compare/log4j-example?expand=1), and confirmed that this change allowed the application to startup.