### PR TITLE
Migrate version information to device.runtimeVersions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.X.X (TBD)
+
+* Migrate version information to device.runtimeVersions
+  [#141](https://github.com/bugsnag/bugsnag-java/pull/141)
+
 ## 3.4.6 (2019-04-16)
 
 * Swallow Throwables thrown when configuring bugsnag appender

--- a/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
@@ -32,7 +32,7 @@ public class BugsnagSpringConfiguration {
         Callback callback = new Callback() {
             @Override
             public void beforeNotify(Report report) {
-                appendSpringRuntimeVersion(Diagnostics.retrieveRuntimeVersionsMap(report.getDevice()));
+                addSpringRuntimeVersion(report.getDevice());
             }
         };
         bugsnag.addCallback(callback);
@@ -44,15 +44,15 @@ public class BugsnagSpringConfiguration {
         BeforeSendSession beforeSendSession = new BeforeSendSession() {
             @Override
             public void beforeSendSession(SessionPayload payload) {
-                appendSpringRuntimeVersion(Diagnostics.retrieveRuntimeVersionsMap(payload.getDevice()));
+                addSpringRuntimeVersion(payload.getDevice());
             }
         };
         bugsnag.addBeforeSendSession(beforeSendSession);
         return beforeSendSession;
     }
 
-    private void appendSpringRuntimeVersion(Map<String, Object> runtimeVersions) {
-        runtimeVersions.put("springFramework", SpringVersion.getVersion());
+    private void addSpringRuntimeVersion(Map<String, Object> device) {
+        Diagnostics.addDeviceRuntimeVersion(device, "springFramework", SpringVersion.getVersion());
     }
 
     @Bean

--- a/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.core.SpringVersion;
 
 import javax.annotation.PostConstruct;
+import java.util.Map;
 
 /**
  * Configuration to integrate Bugsnag with Spring.
@@ -27,15 +28,31 @@ public class BugsnagSpringConfiguration {
      * Add a callback to add the version of Spring used by the application
      */
     @Bean
-    Callback springVersionCallback() {
+    Callback springVersionErrorCallback() {
         Callback callback = new Callback() {
             @Override
             public void beforeNotify(Report report) {
-                report.addToTab("device", "springVersion", SpringVersion.getVersion());
+                appendSpringRuntimeVersion(Diagnostics.retrieveRuntimeVersionsMap(report.getDevice()));
             }
         };
         bugsnag.addCallback(callback);
         return callback;
+    }
+
+    @Bean
+    BeforeSendSession springVersionSessionCallback() {
+        BeforeSendSession beforeSendSession = new BeforeSendSession() {
+            @Override
+            public void beforeSendSession(SessionPayload payload) {
+                appendSpringRuntimeVersion(Diagnostics.retrieveRuntimeVersionsMap(payload.getDevice()));
+            }
+        };
+        bugsnag.addBeforeSendSession(beforeSendSession);
+        return beforeSendSession;
+    }
+
+    private void appendSpringRuntimeVersion(Map<String, Object> runtimeVersions) {
+        runtimeVersions.put("springFramework", SpringVersion.getVersion());
     }
 
     @Bean

--- a/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
@@ -8,8 +8,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.SpringVersion;
 
-import javax.annotation.PostConstruct;
 import java.util.Map;
+import javax.annotation.PostConstruct;
 
 /**
  * Configuration to integrate Bugsnag with Spring.

--- a/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
@@ -31,7 +31,7 @@ class SpringBootConfiguration {
         Callback callback = new Callback() {
             @Override
             public void beforeNotify(Report report) {
-                appendSpringBootRuntimeVersion(Diagnostics.retrieveRuntimeVersionsMap(report.getDevice()));
+                addSpringRuntimeVersion(report.getDevice());
             }
         };
         bugsnag.addCallback(callback);
@@ -43,15 +43,15 @@ class SpringBootConfiguration {
         BeforeSendSession beforeSendSession = new BeforeSendSession() {
             @Override
             public void beforeSendSession(SessionPayload payload) {
-                appendSpringBootRuntimeVersion(Diagnostics.retrieveRuntimeVersionsMap(payload.getDevice()));
+                addSpringRuntimeVersion(payload.getDevice());
             }
         };
         bugsnag.addBeforeSendSession(beforeSendSession);
         return beforeSendSession;
     }
 
-    private void appendSpringBootRuntimeVersion(Map<String, Object> runtimeVersions) {
-        runtimeVersions.put("springBoot", SpringBootVersion.getVersion());
+    private void addSpringRuntimeVersion(Map<String, Object> device) {
+        Diagnostics.addDeviceRuntimeVersion(device, "springBoot", SpringBootVersion.getVersion());
     }
 
     /**

--- a/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
@@ -10,8 +10,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
-import javax.servlet.ServletRequestListener;
 import java.util.Map;
+import javax.servlet.ServletRequestListener;
 
 /**
  * If spring-boot is loaded, add configuration specific to Spring Boot

--- a/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 import javax.servlet.ServletRequestListener;
+import java.util.Map;
 
 /**
  * If spring-boot is loaded, add configuration specific to Spring Boot
@@ -26,15 +27,31 @@ class SpringBootConfiguration {
      * Add a callback to add the version of Spring Boot used by the application.
      */
     @Bean
-    Callback springBootVersionCallback() {
+    Callback springBootVersionErrorCallback() {
         Callback callback = new Callback() {
             @Override
             public void beforeNotify(Report report) {
-                report.addToTab("device", "springBootVersion", SpringBootVersion.getVersion());
+                appendSpringBootRuntimeVersion(Diagnostics.retrieveRuntimeVersionsMap(report.getDevice()));
             }
         };
         bugsnag.addCallback(callback);
         return callback;
+    }
+
+    @Bean
+    BeforeSendSession springBootVersionSessionCallback() {
+        BeforeSendSession beforeSendSession = new BeforeSendSession() {
+            @Override
+            public void beforeSendSession(SessionPayload payload) {
+                appendSpringBootRuntimeVersion(Diagnostics.retrieveRuntimeVersionsMap(payload.getDevice()));
+            }
+        };
+        bugsnag.addBeforeSendSession(beforeSendSession);
+        return beforeSendSession;
+    }
+
+    private void appendSpringBootRuntimeVersion(Map<String, Object> runtimeVersions) {
+        runtimeVersions.put("springBoot", SpringBootVersion.getVersion());
     }
 
     /**

--- a/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
@@ -157,16 +157,18 @@ public class SpringMvcTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void springVersionSetCorrectly() {
         callRuntimeExceptionEndpoint();
 
         Report report = verifyAndGetReport(delivery);
 
         // Check that the Spring version is set as expected
-        @SuppressWarnings(value = "unchecked") Map<String, Object> deviceMetadata =
-                (Map<String, Object>) report.getMetaData().get("device");
-        assertEquals(SpringVersion.getVersion(), deviceMetadata.get("springVersion"));
-        assertEquals(SpringBootVersion.getVersion(), deviceMetadata.get("springBootVersion"));
+        Map<String, Object> deviceMetadata = report.getDevice();
+        Map<String, Object> runtimeVersions =
+                (Map<String, Object>) deviceMetadata.get("runtimeVersions");
+        assertEquals(SpringVersion.getVersion(), runtimeVersions.get("springFramework"));
+        assertEquals(SpringBootVersion.getVersion(), runtimeVersions.get("springBoot"));
     }
 
     @Test

--- a/bugsnag/src/main/java/com/bugsnag/BeforeSendSession.java
+++ b/bugsnag/src/main/java/com/bugsnag/BeforeSendSession.java
@@ -1,0 +1,5 @@
+package com.bugsnag;
+
+interface BeforeSendSession {
+    void beforeSendSession(SessionPayload payload);
+}

--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -665,4 +665,8 @@ public class Bugsnag {
         }
         return Collections.emptySet();
     }
+
+    void addBeforeSendSession(BeforeSendSession beforeSendSession) {
+        sessionTracker.addBeforeSendSession(beforeSendSession);
+    }
 }

--- a/bugsnag/src/main/java/com/bugsnag/Diagnostics.java
+++ b/bugsnag/src/main/java/com/bugsnag/Diagnostics.java
@@ -45,4 +45,17 @@ class Diagnostics {
         }
         return map;
     }
+
+    @SuppressWarnings("unchecked")
+    static Map<String, Object> retrieveRuntimeVersionsMap(Map<String, Object> device) {
+        Object obj = device.get("runtimeVersions");
+
+        if (obj instanceof Map) {
+            return (Map<String, Object>) obj;
+        } else { // fallback to creating a new map if payload was mutated
+            Map<String, Object> map = new HashMap<String, Object>();
+            device.put("runtimeVersions", map);
+            return map;
+        }
+    }
 }

--- a/bugsnag/src/main/java/com/bugsnag/Diagnostics.java
+++ b/bugsnag/src/main/java/com/bugsnag/Diagnostics.java
@@ -23,7 +23,15 @@ class Diagnostics {
         map.put("hostname", DeviceCallback.getHostnameValue());
         map.put("osName", System.getProperty("os.name"));
         map.put("osVersion", System.getProperty("os.version"));
+        map.put("runtimeVersions", getRuntimeVersions());
         return map;
+    }
+
+    private Map<String, String> getRuntimeVersions() {
+        Map<String, String> runtimeVersions = new HashMap<String, String>();
+        runtimeVersions.put("javaType", System.getProperty("java.runtime.name"));
+        runtimeVersions.put("javaVersion", System.getProperty("java.runtime.version"));
+        return runtimeVersions;
     }
 
     private Map<String, Object> getDefaultAppInfo(Configuration configuration) {

--- a/bugsnag/src/main/java/com/bugsnag/Diagnostics.java
+++ b/bugsnag/src/main/java/com/bugsnag/Diagnostics.java
@@ -47,15 +47,16 @@ class Diagnostics {
     }
 
     @SuppressWarnings("unchecked")
-    static Map<String, Object> retrieveRuntimeVersionsMap(Map<String, Object> device) {
+    static void addDeviceRuntimeVersion(Map<String, Object> device, String key, Object value) {
         Object obj = device.get("runtimeVersions");
+        Map<String, Object> runtimeVersions;
 
         if (obj instanceof Map) {
-            return (Map<String, Object>) obj;
+            runtimeVersions = (Map<String, Object>) obj;
         } else { // fallback to creating a new map if payload was mutated
-            Map<String, Object> map = new HashMap<String, Object>();
-            device.put("runtimeVersions", map);
-            return map;
+            runtimeVersions = new HashMap<String, Object>();
+            device.put("runtimeVersions", runtimeVersions);
         }
+        runtimeVersions.put(key, value);
     }
 }

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
@@ -56,8 +56,6 @@ public class DeviceCallback implements Callback {
     public void beforeNotify(Report report) {
         report
                 .addToTab("device", "osArch", System.getProperty("os.arch"))
-                .addToTab("device", "runtimeName", System.getProperty("java.runtime.name"))
-                .addToTab("device", "runtimeVersion", System.getProperty("java.runtime.version"))
                 .addToTab("device", "locale", Locale.getDefault())
                 .setDeviceInfo("hostname", getHostnameValue())
                 .setDeviceInfo("osName", System.getProperty("os.name"))

--- a/bugsnag/src/test/java/com/bugsnag/SessionPayloadTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/SessionPayloadTest.java
@@ -63,7 +63,7 @@ public class SessionPayloadTest {
 
         JsonNode device = rootNode.get("device");
         assertNotNull(device);
-        assertEquals(3, device.size());
+        assertEquals(4, device.size());
     }
 
 }

--- a/features/meta_data.feature
+++ b/features/meta_data.feature
@@ -10,8 +10,6 @@ Scenario: Sends a handled exception which includes custom metadata added in a no
     When I run spring boot "MetaDataScenario" with the defaults
     Then I should receive a request
     And the request is a valid for the error reporting API
-    And the event "metaData.device.springVersion" is not null
-    And the event "metaData.device.springBootVersion" is not null
     And the event "metaData.Custom.foo" equals "Hello World!"
 
 Scenario: Sends a handled exception which includes custom metadata added in a notify callback for plain Spring app
@@ -19,8 +17,6 @@ Scenario: Sends a handled exception which includes custom metadata added in a no
     Then I should receive a request
     And the request is a valid for the error reporting API
     And the event "metaData.Custom.foo" equals "Hello World!"
-    And the event "metaData.device.springVersion" is not null
-    And the event "metaData.device.springBootVersion" is null
 
 Scenario: Test logback appender with meta data in the config file
     When I run "LogbackScenario" with logback config "meta_data_config.xml"

--- a/features/runtime_versions.feature
+++ b/features/runtime_versions.feature
@@ -7,14 +7,14 @@ Scenario: Runtime versions included in Plain Java error
     Then I should receive a request
     And the request is valid for the error reporting API
     And the payload field "events.0.device.runtimeVersions.javaType" ends with "Runtime Environment"
-    And the payload field "events.0.device.runtimeVersions.javaVersion" starts with "1."
+    And the payload field "events.0.device.runtimeVersions.javaVersion" matches the regex "(\d.)+"
 
 Scenario: Runtime versions included in Spring Framework error
     When I run plain Spring "HandledExceptionScenario" with the defaults
     Then I should receive a request
     And the request is valid for the error reporting API
     And the payload field "events.0.device.runtimeVersions.javaType" ends with "Runtime Environment"
-    And the payload field "events.0.device.runtimeVersions.javaVersion" starts with "1."
+    And the payload field "events.0.device.runtimeVersions.javaVersion" matches the regex "(\d.)+"
     And the payload field "events.0.device.runtimeVersions.springFramework" matches the regex "(\d.)+"
 
 Scenario: Runtime versions included in Spring Boot error
@@ -22,7 +22,7 @@ Scenario: Runtime versions included in Spring Boot error
     Then I should receive a request
     And the request is valid for the error reporting API
     And the payload field "events.0.device.runtimeVersions.javaType" ends with "Runtime Environment"
-    And the payload field "events.0.device.runtimeVersions.javaVersion" starts with "1."
+    And the payload field "events.0.device.runtimeVersions.javaVersion" matches the regex "(\d.)+"
     And the payload field "events.0.device.runtimeVersions.springFramework" matches the regex "(\d.)+"
     And the payload field "events.0.device.runtimeVersions.springBoot" matches the regex "(\d.)+"
 
@@ -33,14 +33,14 @@ Scenario: Runtime versions included in Plain Java session
     Then I should receive a request
     And the request is valid for the session tracking API
     And the payload field "device.runtimeVersions.javaType" ends with "Runtime Environment"
-    And the payload field "device.runtimeVersions.javaVersion" starts with "1."
+    And the payload field "device.runtimeVersions.javaVersion" matches the regex "(\d.)+"
 
 Scenario: Runtime versions included in Spring Framework session
     When I run plain Spring "ManualSessionScenario" with the defaults
     Then I should receive a request
     And the request is valid for the session tracking API
     And the payload field "device.runtimeVersions.javaType" ends with "Runtime Environment"
-    And the payload field "device.runtimeVersions.javaVersion" starts with "1."
+    And the payload field "device.runtimeVersions.javaVersion" matches the regex "(\d.)+"
     And the payload field "device.runtimeVersions.springFramework" matches the regex "(\d.)+"
 
 Scenario: Runtime versions included in Spring Boot session
@@ -48,6 +48,6 @@ Scenario: Runtime versions included in Spring Boot session
     Then I should receive a request
     And the request is valid for the session tracking API
     And the payload field "device.runtimeVersions.javaType" ends with "Runtime Environment"
-    And the payload field "device.runtimeVersions.javaVersion" starts with "1."
+    And the payload field "device.runtimeVersions.javaVersion" matches the regex "(\d.)+"
     And the payload field "device.runtimeVersions.springFramework" matches the regex "(\d.)+"
     And the payload field "device.runtimeVersions.springBoot" matches the regex "(\d.)+"

--- a/features/runtime_versions.feature
+++ b/features/runtime_versions.feature
@@ -1,0 +1,53 @@
+Feature: Runtime versions are included in all requests
+
+### Errors
+
+Scenario: Runtime versions included in Plain Java error
+    When I run "HandledExceptionScenario" with the defaults
+    Then I should receive a request
+    And the request is valid for the error reporting API
+    And the payload field "events.0.device.runtimeVersions.javaType" ends with "Runtime Environment"
+    And the payload field "events.0.device.runtimeVersions.javaVersion" starts with "1."
+
+Scenario: Runtime versions included in Spring Framework error
+    When I run plain Spring "HandledExceptionScenario" with the defaults
+    Then I should receive a request
+    And the request is valid for the error reporting API
+    And the payload field "events.0.device.runtimeVersions.javaType" ends with "Runtime Environment"
+    And the payload field "events.0.device.runtimeVersions.javaVersion" starts with "1."
+    And the payload field "events.0.device.runtimeVersions.springFramework" matches the regex "(\d.)+"
+
+Scenario: Runtime versions included in Spring Boot error
+    When I run spring boot "HandledExceptionScenario" with the defaults
+    Then I should receive a request
+    And the request is valid for the error reporting API
+    And the payload field "events.0.device.runtimeVersions.javaType" ends with "Runtime Environment"
+    And the payload field "events.0.device.runtimeVersions.javaVersion" starts with "1."
+    And the payload field "events.0.device.runtimeVersions.springFramework" matches the regex "(\d.)+"
+    And the payload field "events.0.device.runtimeVersions.springBoot" matches the regex "(\d.)+"
+
+### Sessions
+
+Scenario: Runtime versions included in Plain Java session
+    When I run "ManualSessionScenario" with the defaults
+    Then I should receive a request
+    And the request is valid for the session tracking API
+    And the payload field "device.runtimeVersions.javaType" ends with "Runtime Environment"
+    And the payload field "device.runtimeVersions.javaVersion" starts with "1."
+
+Scenario: Runtime versions included in Spring Framework session
+    When I run plain Spring "ManualSessionScenario" with the defaults
+    Then I should receive a request
+    And the request is valid for the session tracking API
+    And the payload field "device.runtimeVersions.javaType" ends with "Runtime Environment"
+    And the payload field "device.runtimeVersions.javaVersion" starts with "1."
+    And the payload field "device.runtimeVersions.springFramework" matches the regex "(\d.)+"
+
+Scenario: Runtime versions included in Spring Boot session
+    When I run spring boot "ManualSessionScenario" with the defaults
+    Then I should receive a request
+    And the request is valid for the session tracking API
+    And the payload field "device.runtimeVersions.javaType" ends with "Runtime Environment"
+    And the payload field "device.runtimeVersions.javaVersion" starts with "1."
+    And the payload field "device.runtimeVersions.springFramework" matches the regex "(\d.)+"
+    And the payload field "device.runtimeVersions.springBoot" matches the regex "(\d.)+"


### PR DESCRIPTION
## Goal

We should collect the following information in the `device.runtimeVersions` section of the payload:

- Java version
- Java type (runtime environment)
- Spring version
- Spring Boot version

## Changeset

- Moved `device.runtimeName` to `device.runtimeVersions.javaType`
- Moved `device.runtimeVersion` to `device.runtimeVersions.javaVersion`
- Moved `device.metaData.springVersion` to `device.runtimeVersions.springFramework`
- Moved `device.metaData.springBootVersion` to `device.runtimeVersions.springBoot`
- Added package-visible `BeforeSendSessions` callback which is invoked immediately before session delivery and allows mutation of the payload
- Added Spring/Spring Boot session callbacks that add runtime version info for sessions

## Tests

Ran existing tests, and added new mazerunner scenarios to verify that version info is included in both errors/sessions for a plain, Spring, and Spring Boot app.
