### PR TITLE
Allow a BugsnagAppender to be created from an existing client.

### DIFF
--- a/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
@@ -80,9 +80,26 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     /** Bugsnag client. */
     private Bugsnag bugsnag = null;
 
+    /** Creates an appender from an existing Bugsnag client. */
+    public BugsnagAppender(Bugsnag bugsnag) {
+        super();
+        this.bugsnag = bugsnag;
+    }
+
+    /**
+     * Default constructor used by Logback to create a Bugsnag appender that will create it's own
+     * client when required.
+     */
+    @SuppressWarnings("unused")
+    public BugsnagAppender() {
+        this(null);
+    }
+
     @Override
     public void start() {
-        this.bugsnag = createBugsnag();
+        if (bugsnag == null) {
+            this.bugsnag = createBugsnag();
+        }
         super.start();
     }
 

--- a/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
@@ -346,6 +346,19 @@ public class AppenderTest {
         assertArrayEquals(expected, appender.split("one,two,three").toArray());
     }
 
+    @Test
+    public void testCreateFromExistingClient() {
+        Bugsnag client = new Bugsnag("testApiKey");
+        BugsnagAppender appender = new BugsnagAppender(client);
+        // Make sure configuration changes are not passed through to the provided client.
+        appender.setApiKey("newApiKey");
+        // Make sure a new client is not created when starting the appender.
+        appender.start();
+
+        assertEquals(client, appender.getClient());
+        assertEquals("testApiKey", appender.getClient().getConfig().apiKey);
+    }
+
     private StackTraceElement changeClassName(StackTraceElement element, String className) {
         return new StackTraceElement(className,
                 element.getFileName(),


### PR DESCRIPTION
This makes it possible to programatically create a Bugsnag logback appender without having to pass in the configuration options twice (once to the original client, and once again to the appender or defined in the logback XML file). This is especially useful if you are adding callbacks and configuration settings that are the same across the original instance and the Logback appender.

If the appender is created with an existing client, it is not possible to set any of the values of the appender that affect Bugsnag as it would also affect the original client.

## Goal
Make it easier to share the configuration and callbacks between an existing Bugsnag client and a Bugsnag Logback appender.

## Design
This approach was taken to couple the logback and client configurations when both are used. This can be the case when you are using Spring Boot.

## Changeset

### Changed
The BugsnagAppender has an optional constructor with a Bugsnag client argument that can be used as the client for logging.

## Tests
Added a new JUnit test to ensure that the new client is used and not overwritten when the appender is started.

## Discussion

### Alternative Approaches

N/A

### Outstanding Questions

Should we explicitly throw an exception if calling a method on the appender that would change the Bugsnag client configuration when providing a client?

Should the provided client be able to be reconfigured through the appender? This sounds dangerous to me, and the client will only ever be provided if creating the appender programatically.

### Linked issues
N/A

## Review

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
