### PR TITLE
Make FilteredMap key matching case-insensitive

### DIFF
--- a/bugsnag/src/main/java/com/bugsnag/util/FilteredMap.java
+++ b/bugsnag/src/main/java/com/bugsnag/util/FilteredMap.java
@@ -113,7 +113,7 @@ public class FilteredMap implements Map<String, Object> {
         }
 
         for (String filter : keyFilters) {
-            if (key.contains(filter)) {
+            if (key.toLowerCase().contains(filter.toLowerCase())) {
                 return true;
             }
         }

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
@@ -210,9 +210,9 @@ public class BugsnagTest {
                         (Map<String, Object>) requestTab.get("headers");
 
                 assertEquals("[FILTERED]", headersMap.get("Authorization"));
-                assertEquals("User:Password", headersMap.get("authorization"));
+                assertEquals("User:Password", headersMap.get("auth"));
                 assertEquals("[FILTERED]", headersMap.get("Cookie"));
-                assertEquals("123456ABCDEF", headersMap.get("cookie"));
+                assertEquals("[FILTERED]", headersMap.get("x-cookie"));
             }
 
             @Override
@@ -225,9 +225,9 @@ public class BugsnagTest {
             public void beforeNotify(Report report) {
                 Map<String, String> headers = new HashMap<String, String>();
                 headers.put("Authorization", "User:Password");
-                headers.put("authorization", "User:Password");
+                headers.put("auth", "User:Password");
                 headers.put("Cookie", "123456ABCDEF");
-                headers.put("cookie", "123456ABCDEF");
+                headers.put("x-cookie", "123456ABCDEF");
 
                 report.addToTab("request", "headers", headers);
             }

--- a/bugsnag/src/test/java/com/bugsnag/util/FilteredMapTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/util/FilteredMapTest.java
@@ -17,6 +17,7 @@ public class FilteredMapTest {
 
     private static final String KEY_UNFILTERED = "unfiltered";
     private static final String KEY_FILTERED = "auth";
+    private static final String KEY_FILTERED_UPPERCASE = "myAuth";
     private static final String KEY_NESTED = "nested";
     private static final String KEY_UNMODIFIABLE = "unmodifiable";
     private static final String VAL_UNFILTERED = "Foo";
@@ -34,6 +35,7 @@ public class FilteredMapTest {
         HashMap<String, Object> map = new HashMap<String, Object>();
         map.put(KEY_UNFILTERED, VAL_UNFILTERED);
         map.put(KEY_FILTERED, VAL_FILTERED);
+        map.put(KEY_FILTERED_UPPERCASE, VAL_FILTERED);
 
         HashMap<String, Object> nestedMap = new HashMap<String, Object>();
         nestedMap.put(KEY_UNFILTERED, VAL_UNFILTERED);
@@ -47,7 +49,7 @@ public class FilteredMapTest {
 
     @Test
     public void testSize() {
-        assertEquals(4, filteredMap.size());
+        assertEquals(5, filteredMap.size());
     }
 
     @Test
@@ -60,7 +62,7 @@ public class FilteredMapTest {
 
     @Test
     public void testClear() {
-        assertEquals(4, filteredMap.size());
+        assertEquals(5, filteredMap.size());
         filteredMap.clear();
         assertTrue(filteredMap.isEmpty());
     }
@@ -94,6 +96,7 @@ public class FilteredMapTest {
     @Test
     public void testGet() {
         assertEquals(PLACEHOLDER_FILTERED, filteredMap.get(KEY_FILTERED));
+        assertEquals(PLACEHOLDER_FILTERED, filteredMap.get(KEY_FILTERED_UPPERCASE));
         assertEquals(VAL_UNFILTERED, filteredMap.get(KEY_UNFILTERED));
 
         Object actual = filteredMap.get(KEY_NESTED);
@@ -108,7 +111,7 @@ public class FilteredMapTest {
     @Test
     public void testKeySet() {
         Set<String> keySet = filteredMap.keySet();
-        assertEquals(4, keySet.size());
+        assertEquals(5, keySet.size());
         assertTrue(keySet.contains(KEY_FILTERED));
         assertTrue(keySet.contains(KEY_UNFILTERED));
         assertTrue(keySet.contains(KEY_NESTED));
@@ -117,7 +120,7 @@ public class FilteredMapTest {
     @Test
     public void testValues() {
         Collection<Object> values = filteredMap.values();
-        assertEquals(4, values.size());
+        assertEquals(5, values.size());
         assertTrue(values.contains(VAL_UNFILTERED));
         assertTrue(values.contains(PLACEHOLDER_FILTERED));
 
@@ -139,7 +142,7 @@ public class FilteredMapTest {
     @Test
     public void testEntrySet() {
         Set<Map.Entry<String, Object>> entries = filteredMap.entrySet();
-        assertEquals(4, entries.size());
+        assertEquals(5, entries.size());
 
         int expectedCount = 0;
 


### PR DESCRIPTION
# Goal

`FilteredMap` is currently case-sensitive, making complete matching tedious. For example, to match the keys `password`, `USER_PASSWORD`, and `adminPassword` would require three separate filters, `password`, `PASSWORD`, and `Password`. Filtering becomes simpler, and less surprising, if matching is case-insensitive.

## Changeset

### Changed

`FilteredMap#shouldFilterKey` converts both the key and filter to lower case before matching.

## Tests

`FilteredMapTest` has additional test cases.

## Discussion

### Alternative Approaches

None

### Outstanding Questions

None

### Linked issues

Fixes #152

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
