### PR TITLE
fix: jvm hangs when System.exit or bugsnag.close is not called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Fix JVM hang when System.exit or bugsnag.close is not called
+  [#157](https://github.com/bugsnag/bugsnag-java/pull/157)
+
 ## 3.6.1 (2019-15-08)
 
 * Prevent potential ConcurrentModificationException when adding callback

--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -3,6 +3,7 @@ package com.bugsnag;
 import com.bugsnag.callbacks.Callback;
 import com.bugsnag.delivery.Delivery;
 import com.bugsnag.delivery.HttpDelivery;
+import com.bugsnag.util.DaemonThreadFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +47,7 @@ public class Bugsnag implements Closeable {
 
     private ScheduledThreadPoolExecutor sessionExecutorService =
             new ScheduledThreadPoolExecutor(CORE_POOL_SIZE,
-                    Executors.defaultThreadFactory(),
+                    new DaemonThreadFactory(),
                     new RejectedExecutionHandler() {
                 @Override
                 public void rejectedExecution(Runnable runnable, ThreadPoolExecutor executor) {

--- a/bugsnag/src/main/java/com/bugsnag/util/DaemonThreadFactory.java
+++ b/bugsnag/src/main/java/com/bugsnag/util/DaemonThreadFactory.java
@@ -1,0 +1,32 @@
+package com.bugsnag.util;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * Wraps {@link Executors#defaultThreadFactory()} to return daemon threads
+ * This is to prevent applications from hanging waiting for the sessions scheduled task
+ * because daemon threads will be terminated on application shutdown
+ */
+public class DaemonThreadFactory implements ThreadFactory {
+    private final ThreadFactory defaultThreadFactory;
+
+    /**
+     * Constructor
+     */
+    public DaemonThreadFactory() {
+        defaultThreadFactory = Executors.defaultThreadFactory();
+    }
+
+    @Override
+    public Thread newThread(Runnable runner) {
+        Thread daemonThread = defaultThreadFactory.newThread(runner);
+        daemonThread.setName("bugsnag-daemon-" + daemonThread.getId());
+
+        // Set the threads to daemon to allow the app to shutdown properly
+        if (!daemonThread.isDaemon()) {
+            daemonThread.setDaemon(true);
+        }
+        return daemonThread;
+    }
+}

--- a/bugsnag/src/test/java/com/bugsnag/DaemonThreadFactoryTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/DaemonThreadFactoryTest.java
@@ -1,0 +1,33 @@
+package com.bugsnag;
+
+import static org.junit.Assert.assertTrue;
+
+import com.bugsnag.util.DaemonThreadFactory;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+/**
+ * Tests for the Daemon thread factory internal logic
+ */
+public class DaemonThreadFactoryTest {
+
+    private DaemonThreadFactory daemonThreadFactory;
+
+    /**
+     * Create the daemonThreadFactory before the tests
+     */
+    @Before
+    public void createFactory() {
+        daemonThreadFactory = new DaemonThreadFactory();
+    }
+
+    @Test
+    public void testDaemonThreadFactory() {
+        Thread testThread = daemonThreadFactory.newThread(null);
+
+        // Check that the thread is as expected
+        assertTrue(testThread.isDaemon());
+    }
+}

--- a/examples/simple/src/main/java/com/bugsnag/example/simple/ExampleApp.java
+++ b/examples/simple/src/main/java/com/bugsnag/example/simple/ExampleApp.java
@@ -74,7 +74,5 @@ public class ExampleApp {
 
         // Wait for unhandled exception thread to finish before exiting
         thread.join();
-
-        System.exit(0);
     }
 }

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/mazerunner/TestCaseRunner.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/mazerunner/TestCaseRunner.java
@@ -6,8 +6,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.ExitCodeGenerator;
-import org.springframework.boot.SpringApplication;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.stereotype.Component;
@@ -41,15 +39,6 @@ public class TestCaseRunner implements CommandLineRunner, ApplicationContextAwar
         } else {
             LOGGER.error("No test case found for " + System.getenv("EVENT_TYPE"));
         }
-
-        // Exit the application
-        LOGGER.info("Exiting spring");
-        System.exit(SpringApplication.exit(ctx, (ExitCodeGenerator) new ExitCodeGenerator() {
-            @Override
-            public int getExitCode() {
-                return 0;
-            }
-        }));
     }
 
     private void setupBugsnag() {


### PR DESCRIPTION
## Goal

The fix to prevent a resource leak in #143 improved the shutdown hook to prevent the resource leak (calling `ExceptionHandler.disable` and `config.delivery.close`) but also reverted the task scheduler from running as a daemon thread. Therefore, in a console app, or similar, which doesn't explicitly call `System.exit`, the JVM waits indefinitely for the `sessionExecutorService` to stop before triggering the shutdown hook.

This PR should be the benefits of both #143 and #121 to gracefully shutdown in both use cases.

Fixes #151 

## Changeset

* Reinstated the `DaemonThreadFactory` (removed in #143)
* Removed `System.exit` calls from the Spring Boot example as the explicit call should not be required.

## Testing

* Updated the "mazerunner" (Spring boot app) end-to-end test to remove the `System.exit` call to test this in future.
* Also ran the fix in a standalone Tomcat war to ensure the warnings about resource leaks were not seen.