### PR TITLE
test(mazerunner): fix failing tests for plain spring app due to tomcat root change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', :git => 'https://github.com/bugsnag/maze-runner'
+gem 'bugsnag-maze-runner', :git => 'https://github.com/bugsnag/maze-runner', :branch => 'v1'
 gem 'os'

--- a/features/async_method.feature
+++ b/features/async_method.feature
@@ -31,7 +31,7 @@ Scenario: Notify an exception from a spring boot async method
 
 Scenario: Report an exception from a plain spring async method
     Given I run the plain spring app
-    When I navigate to the route "/mazerunnerplainspring/run-async-task" on port "1235"
+    When I navigate to the route "/run-async-task" on port "1235"
     Then I should receive a request
     And the request is a valid for the error reporting API
     And the request used the Spring notifier

--- a/features/fixtures/mazerunnerplainspring/Dockerfile
+++ b/features/fixtures/mazerunnerplainspring/Dockerfile
@@ -1,3 +1,3 @@
 FROM tomcat:7.0
 
-COPY /build/libs/mazerunnerplainspring.war /usr/local/tomcat/webapps/mazerunnerplainspring.war
+COPY /build/libs/mazerunnerplainspring.war /usr/local/tomcat/webapps/ROOT.war

--- a/features/fixtures/mazerunnerplainspring/src/main/java/com.bugsnag.mazerunnerplainspring/TestRestController.java
+++ b/features/fixtures/mazerunnerplainspring/src/main/java/com.bugsnag.mazerunnerplainspring/TestRestController.java
@@ -27,6 +27,11 @@ public class TestRestController {
     @Autowired
     private AsyncMethodService asyncMethodService;
 
+    @RequestMapping("/")
+    public String ping() {
+        return "Plain Spring Fixture app ready for connections";
+    }
+
     @RequestMapping("/send-unhandled-exception")
     public void sendUnhandledException() {
         throw new RuntimeException("Unhandled exception from TestRestController");

--- a/features/meta_data.feature
+++ b/features/meta_data.feature
@@ -144,7 +144,7 @@ Scenario: Test logback appender with thread meta data
 
 Scenario: Test thread meta data in plain spring async method
     Given I run the plain spring app
-    When I navigate to the route "/mazerunnerplainspring/run-async-task" on port "1235"
+    When I navigate to the route "/run-async-task" on port "1235"
     Then I should receive a request
     And the request is a valid for the error reporting API
     And the event "metaData.thread.key1" is null

--- a/features/rest_controller.feature
+++ b/features/rest_controller.feature
@@ -18,7 +18,7 @@ Scenario: Report an exception from a spring boot rest controller
 
 Scenario: Report an exception from a plain spring rest controller
     Given I run the plain spring app
-    When I navigate to the route "/mazerunnerplainspring/send-unhandled-exception" on port "1235"
+    When I navigate to the route "/send-unhandled-exception" on port "1235"
     Then I should receive a request
     And the request is a valid for the error reporting API
     And the request used the Spring notifier
@@ -26,7 +26,7 @@ Scenario: Report an exception from a plain spring rest controller
     And the payload field "events" is an array with 1 element
     And the event "unhandled" is true
     And the event "severity" equals "error"
-    And the event "context" equals "GET /mazerunnerplainspring/send-unhandled-exception"
+    And the event "context" equals "GET /send-unhandled-exception"
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "Unhandled exception from TestRestController"
     And the event "metaData.request.url" ends with "/send-unhandled-exception"

--- a/features/session_tracking_auto.feature
+++ b/features/session_tracking_auto.feature
@@ -14,12 +14,13 @@ Scenario: Report automatic session from a spring boot app
 Scenario: Report automatic session from a plain spring app
     Given I set environment variable "AUTO_CAPTURE_SESSIONS" to "true"
     And I run the plain spring app
-    When I navigate to the route "/mazerunnerplainspring/add-session" on port "1235"
+    When I navigate to the route "/add-session" on port "1235"
     Then I should receive a request
     And the request is a valid for the session tracking API
     And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
     And the payload field "sessionCounts" is an array with 1 element
     And the payload field "sessionCounts.0.startedAt" is not null
-    And the payload field "sessionCounts.0.sessionsStarted" equals 1
+    And the payload field "sessionCounts.0.sessionsStarted" equals 2
+    # (1 session for the start-up check on "/" and the second for "/add-session")
     And the payload field "app" is not null
     And the payload field "app.version" equals "1.0.0"

--- a/features/steps/build_steps.rb
+++ b/features/steps/build_steps.rb
@@ -40,7 +40,7 @@ end
 When("I run plain Spring {string} with the defaults") do |eventType|
   steps %Q{
     And I run the plain spring app
-    And I navigate to the route "/mazerunnerplainspring/run-scenario/#{eventType}" on port "1235"
+    And I navigate to the route "/run-scenario/#{eventType}" on port "1235"
   }
 end
 


### PR DESCRIPTION
## Goal

It appears that Tomcat 7.0 no longer has a ROOT webapp and so serves a 404 instead. This was being used by Mazerunner to check whether the app had started yet. However I believe it's more correct to check the deployed application rather than this placeholder app.

## Changeset

This changeset deploys the spring app to the root and amends the tests to run from the root.

## Testing

A consequence of this is that the automatic session tracking tests are affected as each test starts by accessing a page and incrementing the counts. Therefore the scenario's expectation has been updated (and annotated) to expect a second count.
