### PR TITLE
docs(readme): fix broken license file link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ All contributors are welcome! For information on how to build, test, and release
 
 ## License
 
-The Bugsnag Java library is free software released under the MIT License. See [LICENSE.txt](https://github.com/bugsnag/bugsnag-java/blob/master/LICENSE.txt) for details.
+The Bugsnag Java library is free software released under the MIT License. See [LICENSE](https://github.com/bugsnag/bugsnag-java/blob/master/LICENSE) for details.


### PR DESCRIPTION
## Goal

Fixes link to the license file.