### PR TITLE
Avoid using jcenter() in build scripts

### DIFF
--- a/bugsnag-spring/build.gradle
+++ b/bugsnag-spring/build.gradle
@@ -9,7 +9,6 @@ apply from: '../common.gradle'
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {

--- a/bugsnag/build.gradle
+++ b/bugsnag/build.gradle
@@ -7,7 +7,6 @@ apply from: '../common.gradle'
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,9 @@
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
     }
     dependencies {
         if (project.hasProperty('releasing')) {
-            classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
             classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
             classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.11.0'
             classpath 'net.researchgate:gradle-release:2.4.0'

--- a/examples/logback/build.gradle
+++ b/examples/logback/build.gradle
@@ -3,13 +3,11 @@ apply plugin: 'application'
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
     }
 }
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {

--- a/examples/servlet/build.gradle
+++ b/examples/servlet/build.gradle
@@ -5,7 +5,6 @@ apply plugin: 'org.akhikhl.gretty'
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -15,7 +14,6 @@ buildscript {
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {

--- a/examples/simple/build.gradle
+++ b/examples/simple/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'application'
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {

--- a/examples/spring-web/build.gradle
+++ b/examples/spring-web/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     }
     repositories {
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
@@ -17,7 +16,6 @@ apply plugin: 'io.spring.dependency-management'
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {

--- a/examples/spring/build.gradle
+++ b/examples/spring/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     }
     repositories {
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
@@ -17,7 +16,6 @@ apply plugin: 'io.spring.dependency-management'
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {

--- a/features/fixtures/mazerunner/build.gradle
+++ b/features/fixtures/mazerunner/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     }
     repositories {
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
@@ -25,7 +24,6 @@ repositories {
     flatDir {
         dirs '../libs'
     }
-    jcenter()
 }
 
 dependencies {

--- a/features/fixtures/mazerunnerplainspring/build.gradle
+++ b/features/fixtures/mazerunnerplainspring/build.gradle
@@ -11,7 +11,6 @@ repositories {
     flatDir {
         dirs '../libs'
     }
-    jcenter()
 }
 
 dependencies {

--- a/features/fixtures/mazerunnerspringboot/build.gradle
+++ b/features/fixtures/mazerunnerspringboot/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     }
     repositories {
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
@@ -25,7 +24,6 @@ repositories {
     flatDir {
         dirs '../libs'
     }
-    jcenter()
 }
 
 dependencies {

--- a/features/fixtures/scenarios/build.gradle
+++ b/features/fixtures/scenarios/build.gradle
@@ -9,7 +9,6 @@ repositories {
     flatDir {
         dirs '../libs'
     }
-    jcenter()
 }
 
 dependencies {

--- a/release.gradle
+++ b/release.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.bmuschko.nexus'
 apply plugin: 'net.researchgate.release'
 apply plugin: 'maven-publish'
@@ -63,23 +62,6 @@ publishing {
             artifact sourceJar {
                 classifier "sources"
             }
-        }
-    }
-}
-// Bintray upload
-bintray {
-    user = "$bintray_user"
-    key = "$bintray_api_key"
-    publications = ['Publication']
-    pkg {
-        repo = 'maven'
-        name = project.findProperty('artifactId')
-        userOrg = 'bugsnag'
-        licenses = ['MIT']
-        vcsUrl = 'https://github.com/bugsnag/bugsnag-java.git'
-        version {
-            name = rootProject.version
-            vcsTag = "v${rootProject.version}"
         }
     }
 }


### PR DESCRIPTION
## Goal

JCenter has reached end-of-life so mavenCentral should be preferred as a repository. This alters the build scripts of bugsnag-java to avoid using jcenter(), and removes the obsolete bintray publish plugin.

## Testing

Assembled projects and ran tests locally, also relied on CI.