### PR TITLE
Suggested change to fix logging of handled exceptions

### DIFF
--- a/bugsnag-spring/src/main/java/com/bugsnag/BugsnagMvcExceptionHandler.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/BugsnagMvcExceptionHandler.java
@@ -2,24 +2,20 @@ package com.bugsnag;
 
 import com.bugsnag.HandledState.SeverityReasonType;
 
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.ModelAndView;
 
 import java.util.Collections;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
  * Reports uncaught exceptions thrown from handler mapping or execution to Bugsnag
  * and then passes the exception to the next handler in the chain.
- *
+ * <p>
  * Set to highest precedence so that it should be called before other exception
  * resolvers.
  */
-@Order(Ordered.HIGHEST_PRECEDENCE)
 class BugsnagMvcExceptionHandler implements HandlerExceptionResolver {
 
     private final Bugsnag bugsnag;
@@ -48,3 +44,4 @@ class BugsnagMvcExceptionHandler implements HandlerExceptionResolver {
         return null;
     }
 }
+

--- a/bugsnag-spring/src/main/java/com/bugsnag/MvcConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/MvcConfiguration.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.HandlerExceptionResolver;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 import java.util.List;
 import javax.annotation.PostConstruct;
@@ -14,7 +14,7 @@ import javax.annotation.PostConstruct;
  */
 @Configuration
 @Conditional(SpringWebMvcLoadedCondition.class)
-class MvcConfiguration extends WebMvcConfigurationSupport {
+class MvcConfiguration extends WebMvcConfigurerAdapter {
 
     @Autowired
     private Bugsnag bugsnag;
@@ -41,7 +41,7 @@ class MvcConfiguration extends WebMvcConfigurationSupport {
      * Only unhandled exceptions shall be sent to Bugsnag.
      */
     @Override
-    protected void extendHandlerExceptionResolvers(List<HandlerExceptionResolver> exceptionResolvers) {
+    public void extendHandlerExceptionResolvers(List<HandlerExceptionResolver> exceptionResolvers) {
         final int position = exceptionResolvers.isEmpty() ? 0 : exceptionResolvers.size() - 1;
         exceptionResolvers.add(position, new BugsnagMvcExceptionHandler(bugsnag));
     }

--- a/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
@@ -172,6 +172,20 @@ public class SpringMvcTest {
     }
 
     @Test
+    public void noBugsnagNotifyOnResponseStatusException() {
+        callResponseStatusExceptionEndpoint();
+
+        verifyNoReport();
+    }
+
+    @Test
+    public void noBugsnagNotifyOnExceptionHandledByExceptionHandlerException() {
+        callResponseStatusExceptionEndpoint();
+
+        verifyNoReport();
+    }
+
+    @Test
     public void unhandledTypeMismatchExceptionSeverityInfo() {
         callUnhandledTypeMismatchExceptionEndpoint();
 
@@ -240,6 +254,16 @@ public class SpringMvcTest {
     private void callUnhandledTypeMismatchExceptionEndpoint() {
         this.restTemplate.getForEntity(
                 "/throw-type-mismatch-exception", String.class);
+    }
+
+    private void callResponseStatusExceptionEndpoint() {
+        this.restTemplate.getForEntity(
+                "/throw-response-status-exception", String.class);
+    }
+
+    private void callCustomExceptionEndpoint() {
+        this.restTemplate.getForEntity(
+                "/throw-custom-exception", String.class);
     }
 
     private void callHandledTypeMismatchExceptionUserSeverityEndpoint() {

--- a/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestController.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestController.java
@@ -34,6 +34,22 @@ public class TestController {
     }
 
     /**
+     * Throw an exception with @ResponseStatus
+     */
+    @RequestMapping("/throw-response-status-exception")
+    public void throwResponseStatusException() {
+        throw new TestResponseStatusException();
+    }
+
+    /**
+     * Throw an exception that is handled by @ExceptionHandler
+     */
+    @RequestMapping("/throw-custom-exception")
+    public void throwCustomException() {
+        throw new TestCustomException();
+    }
+
+    /**
      * Report a handled exception where the severity reason is exceptionClass
      */
     @RequestMapping("/handled-type-mismatch-exception")

--- a/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestCustomException.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestCustomException.java
@@ -1,0 +1,4 @@
+package com.bugsnag.testapp.springboot;
+
+public class TestCustomException extends RuntimeException {
+}

--- a/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestExceptionHandler.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestExceptionHandler.java
@@ -1,0 +1,13 @@
+package com.bugsnag.testapp.springboot;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class TestExceptionHandler {
+    @ExceptionHandler(TestCustomException.class)
+    public ResponseEntity handleTestCustomException(TestCustomException ignored) {
+        return ResponseEntity.ok(TestCustomException.class.getSimpleName());
+    }
+}

--- a/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestResponseStatusException.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestResponseStatusException.java
@@ -1,0 +1,9 @@
+package com.bugsnag.testapp.springboot;
+
+import static org.springframework.http.HttpStatus.I_AM_A_TEAPOT;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(I_AM_A_TEAPOT)
+public class TestResponseStatusException extends RuntimeException {
+}


### PR DESCRIPTION
I had an idea how to fix #156 and would love some feedback on this approach. If the approach looks okay to you, I would spend some more time to add tests to verify the changed behaviour (namely `@ResponseStatus` exceptions and `@ExceptionHandler` methods get to handle the exception first and therefore can prevent BugSnag from logging it).

## Goal

Fix #156 

## Design

Just changing the Order of the `BugsnagMvcExceptionHandler` does not work, because all the three exception handlers have the same (lowest) precedence but are grouped in the `HandlerExceptionResolverComposite`.  This approach injects BugSnag as the second last exception handler just before the `DefaultHandlerExceptionResolver`.

## Changeset

The `BugsnagMvcExceptionHandler` is injected manually at the right position and not by Spring ordering.

## Testing

Existing tests still pass. I added two new test to test that exceptions handled by `@ResponseStatus` and `@ExceptionHandler` are not sent to BugSnag.