### PR TITLE
Migrate unit tests to buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,3 +4,19 @@ steps:
     plugins:
       - docker-compose#v3.7.0:
           run: license-audit
+
+  - label: ':docker: Assemble project'
+    key: 'java-jvm-build'
+    timeout_in_minutes: 30
+    plugins:
+      - docker-compose#v3.7.0:
+          run: java-common
+    command: './gradlew :bugsnag:assemble :bugsnag-spring:assemble'
+
+  - label: ':docker: Run JVM tests'
+    key: 'java-jvm-tests'
+    timeout_in_minutes: 30
+    plugins:
+      - docker-compose#v3.7.0:
+          run: java-common
+    command: './gradlew check test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,26 +13,6 @@ install: ./gradlew :bugsnag:assemble :bugsnag-spring:assemble
 jobs:
   include:
   - stage: test
-    jdk: openjdk8
-    script:
-      - ./gradlew check test
-  - stage: test
-    jdk: oraclejdk9
-    script:
-      - ./gradlew check test
-  - stage: test
-    jdk: oraclejdk8
-    script:
-      - ./gradlew check test
-  - stage: test
-    jdk: openjdk7
-    script:
-      - ./gradlew check test
-    before_install: # Work around missing crypto in openjdk7
-    - sudo wget "https://bouncycastle.org/download/bcprov-ext-jdk15on-158.jar" -O "${JAVA_HOME}/jre/lib/ext/bcprov-ext-jdk15on-158.jar"
-    - sudo perl -pi.bak -e 's/^(security\.provider\.)([0-9]+)/$1.($2+1)/ge' /etc/java-7-openjdk/security/java.security
-    - echo "security.provider.1=org.bouncycastle.jce.provider.BouncyCastleProvider" | sudo tee -a /etc/java-7-openjdk/security/java.security
-  - stage: test
     name: mazerunner
     jdk: openjdk8
     script:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,7 @@ services:
     build:
       context: .
       dockerfile: dockerfiles/Dockerfile.license-audit
+  java-common:
+    build:
+      context: .
+      dockerfile: dockerfiles/Dockerfile.java-common

--- a/dockerfiles/Dockerfile.java-common
+++ b/dockerfiles/Dockerfile.java-common
@@ -1,0 +1,13 @@
+FROM openjdk:8
+WORKDIR /app
+
+# Force download of gradle zip early to avoid repeating
+# if Docker cache is invalidated by branch changes.
+COPY gradlew gradle.properties /app/
+COPY gradle/ /app/gradle/
+ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
+COPY settings.gradle /app/
+RUN ./gradlew
+
+# Copy repo into docker
+COPY . /app


### PR DESCRIPTION
## Goal

Migrates our unit tests to Buildkite, which avoids needing to run them on Travis CI.

I've gone for the approach of running the style checks/unit/integration tests against OpenJdk 8 only. I think it makes more sense to run the mazerunner tests against different JDK distributions if we're going to go down that road.

The mazerunner tests will be ported over in a separate changeset.