### PR TITLE
Support formatted log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Bump Jackson from 2.9.1 for critical vulnerability fixes
   [#170](https://github.com/bugsnag/bugsnag-java/pull/170)
 
+* Support log messages that use `{}` formatting
+  [#178]{https://github.com/bugsnag/bugsnag-java/pull/178}
+
 ## 3.6.2 (2020-11-10)
 
 * Fix JVM hang when System.exit or bugsnag.close is not called

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
@@ -138,7 +138,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
                                 // Add some data from the logging event
                                 report.addToTab("Log event data",
-                                        "Message", event.getMessage());
+                                        "Message", event.getFormattedMessage());
                                 report.addToTab("Log event data",
                                         "Logger name", event.getLoggerName());
 

--- a/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
@@ -30,6 +30,9 @@ import java.util.Map;
 public class AppenderTest {
 
     private static final Logger LOGGER = Logger.getLogger(AppenderTest.class);
+
+    private static final org.slf4j.Logger SLF_LOGGER = LoggerFactory.getLogger(AppenderTest.class);
+
     private StubNotificationDelivery delivery;
     private StubSessionDelivery sessionDelivery;
     private Delivery originalDelivery;
@@ -84,6 +87,28 @@ public class AppenderTest {
         assertEquals("test", notification.getEvents().get(0).getExceptionMessage());
         assertEquals(Severity.WARNING.getValue(), notification.getEvents().get(0).getSeverity());
         assertEquals("Test exception",
+                getMetaDataMap(notification, "Log event data").get("Message"));
+    }
+
+    @Test
+    public void testFormattedMessage() {
+        int value = 1234;
+
+        // Send a test log
+        SLF_LOGGER.warn("Test exception, errorCode: {}", value, new RuntimeException("test"));
+
+        String message = "no exception";
+        // Send a log with no exception
+        SLF_LOGGER.warn("Test log with {}", message);
+
+        // Check that one report was sent to Bugsnag
+        assertEquals(1, delivery.getNotifications().size());
+
+        // Check the correct event was created
+        Notification notification = delivery.getNotifications().get(0);
+        assertEquals("test", notification.getEvents().get(0).getExceptionMessage());
+        assertEquals(Severity.WARNING.getValue(), notification.getEvents().get(0).getSeverity());
+        assertEquals("Test exception, errorCode: " + value,
                 getMetaDataMap(notification, "Log event data").get("Message"));
     }
 


### PR DESCRIPTION
## Goal
Support error messages that use `{}` formatting in `"Log event data"`.

## Testing
Added a new unit test to cover formatted messages via an slf4j logger.