### PR TITLE
PIPE-5521: Remove dependency on gradle-nexus-plugin

### DIFF
--- a/bugsnag-spring/build.gradle
+++ b/bugsnag-spring/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 
 evaluationDependsOnChildren()
 
-tasks['jar'].mustRunAfter(project(':bugsnag-spring:javax').tasks['jar'])
+tasks['jar'].dependsOn(project(':bugsnag-spring:javax').tasks['jar'])
 
 jar {
     from project.sourceSets.main.allSource

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,14 @@
 buildscript {
     repositories {
         mavenCentral()
+        maven {
+            url = uri("https://plugins.gradle.org/m2/")
+        }
     }
     dependencies {
         if (project.hasProperty('releasing')) {
-            classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
-            classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.11.0'
-            classpath 'net.researchgate:gradle-release:2.4.0'
+            classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0'
+            classpath 'net.researchgate:gradle-release:3.0.2'
         }
     }
 }

--- a/common.gradle
+++ b/common.gradle
@@ -11,7 +11,7 @@ if (JavaVersion.current().isJava8Compatible()) {
     apply plugin: 'checkstyle'
 }
 
-if (project.hasProperty('releasing')) {
+if (project.hasProperty('releasing') && project.depth <= 1) {
     apply from: "../release.gradle"
 }
 

--- a/release.gradle
+++ b/release.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'com.bmuschko.nexus'
 apply plugin: 'net.researchgate.release'
 apply plugin: 'maven-publish'
 
@@ -11,41 +10,6 @@ release {
 
 nexusStaging {
     packageGroup = "com.bugsnag"
-}
-
-modifyPom {
-    project {
-        name = project.findProperty('projectName')
-        description = project.findProperty('projectDescription')
-        url 'https://github.com/bugsnag/bugsnag-java'
-
-        scm {
-            url 'https://github.com/bugsnag/bugsnag-java'
-            connection 'scm:git:git://github.com/bugsnag/bugsnag-java.git'
-            developerConnection 'scm:git:ssh://git@github.com/bugsnag/bugsnag-java.git'
-        }
-
-        licenses {
-            license {
-                name 'MIT'
-                url 'http://opensource.org/licenses/MIT'
-                distribution 'repo'
-            }
-        }
-
-        organization {
-            name 'Bugsnag'
-            url 'https://bugsnag.com'
-        }
-
-        developers {
-            developer {
-                id 'loopj'
-                name 'James Smith'
-                email 'james@bugsnag.com'
-            }
-        }
-    }
 }
 
 task sourceJar(type: Jar) {
@@ -61,6 +25,38 @@ publishing {
             version rootProject.version
             artifact sourceJar {
                 classifier "sources"
+            }
+            pom {
+                name = project.findProperty('projectName')
+                description = project.findProperty('projectDescription')
+                url = 'https://github.com/bugsnag/bugsnag-java'
+
+                scm {
+                    url = 'https://github.com/bugsnag/bugsnag-java'
+                    connection = 'scm:git:git://github.com/bugsnag/bugsnag-java.git'
+                    developerConnection = 'scm:git:ssh://git@github.com/bugsnag/bugsnag-java.git'
+                }
+
+                licenses {
+                    license {
+                        name = 'MIT'
+                        url = 'http://opensource.org/licenses/MIT'
+                        distribution = 'repo'
+                    }
+                }
+
+                organization {
+                    name = 'Bugsnag'
+                    url = 'https://bugsnag.com'
+                }
+
+                developers {
+                    developer {
+                        id = 'loopj'
+                        name = 'James Smith'
+                        email = 'james@bugsnag.com'
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Goal

Enable the command `./gradlew -Preleasing=true publishToMavenLocal` as this was missed when initially upgraded to gradle v7. 

## Design

Similar approach to BAGP

## Changeset

Removed the gradle-nexus-plugin and replaced with pom directive.
Prevent release of subprojects spring:javax and spring:jakarta using project.depth
Ensure spring:javax jar exists before packaging bugsnag-spring using 'dependsOn' 

## Testing

Tested under PLAT-9981