### PR TITLE
Restored the `com.bugsnag.servlet` (javax) classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+* Restore `BugsnagServletContainerInitializer` and `BugsnagServletRequestListener` to the `com.bugsnag.servlet` package.
+  These classes are deprecated in favour of the new `com.bugsnag.servlet.javax.` package, but are also compatible (`c.b.s.BugsnagServletRequestListener extends c.b.s.javax.BugsnagServletRequestListener`). This
+  fixes [issue #195](https://github.com/bugsnag/bugsnag-java/issues/195).
+  [#199](https://github.com/bugsnag/bugsnag-java/pull/199)
+
 ## 3.7.0 (2023-06-12)
 
 * Support Spring 6 / Spring Boot 3

--- a/bugsnag-spring/javax/src/main/java/com/bugsnag/SpringBootJavaxConfiguration.java
+++ b/bugsnag-spring/javax/src/main/java/com/bugsnag/SpringBootJavaxConfiguration.java
@@ -17,11 +17,11 @@ import javax.servlet.ServletRequestListener;
 class SpringBootJavaxConfiguration extends SpringBootConfiguration {
 
     /**
-    * The {@link com.bugsnag.servlet.javax.BugsnagServletContainerInitializer} does not work for Spring Boot, need to
-    * register the {@link BugsnagServletRequestListener} using a Spring Boot
-    * {@link ServletListenerRegistrationBean} instead. This adds session tracking and
-    * automatic servlet request metadata collection.
-    */
+     * The {@link com.bugsnag.servlet.javax.BugsnagServletContainerInitializer} does not work for Spring Boot, need to
+     * register the {@link BugsnagServletRequestListener} using a Spring Boot
+     * {@link ServletListenerRegistrationBean} instead. This adds session tracking and
+     * automatic servlet request metadata collection.
+     */
     @Bean
     @Conditional(SpringWebMvcLoadedCondition.class)
     ServletListenerRegistrationBean<ServletRequestListener> listenerRegistrationBean() {

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/JavaxServletCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/JavaxServletCallback.java
@@ -1,7 +1,7 @@
 package com.bugsnag.callbacks;
 
 import com.bugsnag.Report;
-import com.bugsnag.servlet.javax.BugsnagServletRequestListener;
+import com.bugsnag.servlet.BugsnagServletRequestListener;
 
 import java.util.Enumeration;
 import java.util.HashMap;

--- a/bugsnag/src/main/java/com/bugsnag/servlet/BugsnagServletContainerInitializer.java
+++ b/bugsnag/src/main/java/com/bugsnag/servlet/BugsnagServletContainerInitializer.java
@@ -1,0 +1,9 @@
+package com.bugsnag.servlet;
+
+/**
+ * @see com.bugsnag.servlet.javax.BugsnagServletContainerInitializer
+ * @deprecated since 3.7.1 - to be replaced with {@code com.bugsnag.servlet.javax.BugsnagServletContainerInitializer}
+ */
+@Deprecated
+public class BugsnagServletContainerInitializer extends com.bugsnag.servlet.javax.BugsnagServletContainerInitializer {
+}

--- a/bugsnag/src/main/java/com/bugsnag/servlet/BugsnagServletRequestListener.java
+++ b/bugsnag/src/main/java/com/bugsnag/servlet/BugsnagServletRequestListener.java
@@ -1,0 +1,9 @@
+package com.bugsnag.servlet;
+
+/**
+ * @see com.bugsnag.servlet.javax.BugsnagServletRequestListener
+ * @deprecated since 3.7.1 - to be replaced with {@code com.bugsnag.servlet.javax.BugsnagServletRequestListener}
+ */
+@Deprecated
+public class BugsnagServletRequestListener extends com.bugsnag.servlet.javax.BugsnagServletRequestListener {
+}

--- a/bugsnag/src/main/resources/META-INF/services/javax.servlet.ServletContainerInitializer
+++ b/bugsnag/src/main/resources/META-INF/services/javax.servlet.ServletContainerInitializer
@@ -1,1 +1,1 @@
-com.bugsnag.servlet.javax.BugsnagServletContainerInitializer
+com.bugsnag.servlet.BugsnagServletContainerInitializer

--- a/bugsnag/src/test/java/com/bugsnag/JavaxServletCallbackTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/JavaxServletCallbackTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.when;
 
 import com.bugsnag.callbacks.JavaxServletCallback;
 
-import com.bugsnag.servlet.javax.BugsnagServletRequestListener;
+import com.bugsnag.servlet.BugsnagServletRequestListener;
 
 import org.junit.After;
 import org.junit.Before;


### PR DESCRIPTION
## Goal
Restore the public API for:

- `com.bugsnag.servlet.BugsnagServletContainerInitializer`
- `com.bugsnag.servlet.BugsnagServletRequestListener`

## Design
Reintroduced the `com.bugsnag.servlet.BugsnagServletContainerInitializer`, and `com.bugsnag.servlet.BugsnagServletRequestListener` classes as empty sub-classes of `com.bugsnag.servlet.javax.*` so that the migration is clear but existing code will continue to run as-normal.

These "new" `com.bugsnag.servlet.*` classes are marked as `@Deprecated` but are still the classes registered in `META-INF/services`. This means that containers will instantiate these deprecated classes, but that they can be safely downcast to the new `com.bugsnag.servlet.javax` classes.

Any applications that manually register or instantiate the new `com.bugsnag.servlet.javax` classes will not be able to downcast them to the deprecated `com.bugsnag.servlet.*` classes.

## Testing
Relied on existing tests.