### PR TITLE
docs: replace references to `master` with `main`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,15 +122,15 @@ To start a release:
     - `./gradlew -Preleasing=true clean publishAllPublicationsToSonatypeRepository`
     - Verify that the artefacts are uploaded to sonatype - ensure that JARs, POMs and JAVADOCs are present for each module.
     - Test the Sonatype artefacts in the example app by adding the newly created 'combugsnag-XXXX' repository to the build.gradle: maven {url "https://oss.sonatype.org/service/local/repositories/combugsnag-XXXX/content/"}
-- Once you are happy, make a PR from your release branch to `master` entitled `Release vX.Y.Z`
+- Once you are happy, make a PR from your release branch to `main` entitled `Release vX.Y.Z`
 - Get the release PR reviewed – all code changes should have been reviewed already, this should be a review of the integration of all changes to be shipped and the changelog
 - Once merged:
-    - Pull the latest changes (checking out `master` if necessary)
+    - Pull the latest changes (checking out `main` if necessary)
     - Create a release build and upload to sonatype:
         - `./gradlew -Preleasing=true clean publishAllPublicationsToSonatypeRepository`
     - Release to GitHub:
-        - [ ] Create *and tag* the release from `master` on [GitHub Releases](https://github.com/bugsnag/bugsnag-android/releases), attaching the changelog entry and build artifacts
-    - Checkout `master` and pull the latest changes
+        - [ ] Create *and tag* the release from `main` on [GitHub Releases](https://github.com/bugsnag/bugsnag-android/releases), attaching the changelog entry and build artifacts
+    - Checkout `main` and pull the latest changes
     - "Promote" the release build on Maven Central:
         - Go to the [sonatype open source dashboard](https://oss.sonatype.org/index.html#stagingRepositories)
         - Click the search box at the top right, and type “com.bugsnag”

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bugsnag exception reporter for Java
 [![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://docs.bugsnag.com/platforms/java)
-[![Build status](https://travis-ci.org/bugsnag/bugsnag-java.svg?branch=master)](https://travis-ci.org/bugsnag/bugsnag-java)
+[![Build status](https://badge.buildkite.com/de087a23152718c7d33b0ae7f566a940a92fb9d92becdb61a3.svg?branch=main)](https://buildkite.com/bugsnag/bugsnag-java)
 
 The Bugsnag exception reporter for Java automatically detects and reports errors and exceptions in your Java code. Learn more about [reporting Java exceptions](https://www.bugsnag.com/platforms/java/) with Bugsnag.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Bugsnag exception reporter for Java automatically detects and reports errors
 ## Contributing
 
 All contributors are welcome! For information on how to build, test, and release
-`bugsnag-java`, see our [contributing guide](https://github.com/bugsnag/bugsnag-java/blob/master/CONTRIBUTING.md).
+`bugsnag-java`, see our [contributing guide](https://github.com/bugsnag/bugsnag-java/blob/main/CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
## Goal

- Replace references to `master` with `main` in docs (`README.md` and `CONTRIBUTING.md`)
- Update build status badge from Travis CI to Buildkite
