### PR TITLE
Plat 11507 fix bugsnag import selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD 
+
+* Update `BugsnagImportSelector` to allow major versions that do not have a minor version.
+  fixes [issue #211](https://github.com/bugsnag/bugsnag-java/issues/211).
+  [#]()
+
+
 ## 3.7.1 (2023-10-25)
 
 * Restore `BugsnagServletContainerInitializer` and `BugsnagServletRequestListener` to the `com.bugsnag.servlet` package.

--- a/bugsnag-spring/src/common/java/com/bugsnag/BugsnagImportSelector.java
+++ b/bugsnag-spring/src/common/java/com/bugsnag/BugsnagImportSelector.java
@@ -40,11 +40,15 @@ public class BugsnagImportSelector implements ImportSelector {
             return 0;
         }
         int firstDot = version.indexOf(".");
+        String majorVersion;
+
         if (firstDot == -1) {
-            return 0;
+            majorVersion = version;
+        }
+        else{
+            majorVersion = version.substring(0, firstDot);
         }
 
-        String majorVersion = version.substring(0, firstDot);
         try {
             return Integer.parseInt(majorVersion);
         } catch (NumberFormatException nfe) {

--- a/bugsnag-spring/src/common/java/com/bugsnag/BugsnagImportSelector.java
+++ b/bugsnag-spring/src/common/java/com/bugsnag/BugsnagImportSelector.java
@@ -44,8 +44,7 @@ public class BugsnagImportSelector implements ImportSelector {
 
         if (firstDot == -1) {
             majorVersion = version;
-        }
-        else{
+        } else {
             majorVersion = version.substring(0, firstDot);
         }
 


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
Import selector only accepts versions that have a minor version. Requesting changes [here](https://github.com/bugsnag/bugsnag-java/issues/211)

## Changeset

<!-- What changed? -->
BugsnagImportselector.java file edited to allow a major version without a minor version which isn't always the case.

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->
Running automated test