### PR TITLE
Added severity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 * Update `BugsnagImportSelector` to allow major versions that do not have a minor version.
   fixes [issue #211](https://github.com/bugsnag/bugsnag-java/issues/211).
-  [#]()
+  [#213](https://github.com/bugsnag/bugsnag-java/pull/213)
+
+* Add null check to setting severity. Sets Null severity to Severyity.ERROR by default. [#214](https://github.com/bugsnag/bugsnag-java/pull/214)
 
 
 ## 3.7.1 (2023-10-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   fixes [issue #211](https://github.com/bugsnag/bugsnag-java/issues/211).
   [#213](https://github.com/bugsnag/bugsnag-java/pull/213)
 
-* Add null check to setting severity. Sets Null severity to Severyity.ERROR by default. [#214](https://github.com/bugsnag/bugsnag-java/pull/214)
+* Add a null check for `Severity` to the notify override method. [#214](https://github.com/bugsnag/bugsnag-java/pull/214)
 
 
 ## 3.7.1 (2023-10-25)

--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -388,6 +388,10 @@ public class Bugsnag implements Closeable {
             LOGGER.warn("Tried to notify with a null Throwable");
             return false;
         }
+        if (severity == null) {
+            LOGGER.warn("Tried to notify with a null Severity");
+            return false;
+        }
 
         HandledState handledState = HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_USER_SPECIFIED, severity);

--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -389,8 +389,7 @@ public class Bugsnag implements Closeable {
             return false;
         }
         if (severity == null) {
-            LOGGER.warn("Tried to notify with a null Severity");
-            return false;
+            return notify(throwable, callback);
         }
 
         HandledState handledState = HandledState.newInstance(

--- a/bugsnag/src/main/java/com/bugsnag/Report.java
+++ b/bugsnag/src/main/java/com/bugsnag/Report.java
@@ -43,9 +43,6 @@ public class Report {
         this.exception = new Exception(config, throwable);
         this.handledState = handledState;
         this.severity = handledState.getOriginalSeverity();
-        if (this.severity == null) {
-            this.severity = Severity.ERROR;
-        }
         diagnostics = new Diagnostics(this.config);
 
         if (config.sendThreads) {
@@ -284,9 +281,6 @@ public class Report {
      * @return the modified report
      */
     public Report setSeverity(Severity severity) {
-        if (severity == null) {
-            throw new IllegalArgumentException("Severity should not be set to a null value.");
-        }
         this.severity = severity;
         this.handledState.setCurrentSeverity(severity);
         return this;

--- a/bugsnag/src/main/java/com/bugsnag/Report.java
+++ b/bugsnag/src/main/java/com/bugsnag/Report.java
@@ -43,7 +43,7 @@ public class Report {
         this.exception = new Exception(config, throwable);
         this.handledState = handledState;
         this.severity = handledState.getOriginalSeverity();
-        if(this.severity == null) {
+        if (this.severity == null) {
             this.severity = Severity.ERROR;
         }
         diagnostics = new Diagnostics(this.config);
@@ -284,7 +284,7 @@ public class Report {
      * @return the modified report
      */
     public Report setSeverity(Severity severity) {
-        if(severity == null)
+        if (severity == null)
         {
             throw new IllegalArgumentException("Severity should not be set to a null value.");
         }

--- a/bugsnag/src/main/java/com/bugsnag/Report.java
+++ b/bugsnag/src/main/java/com/bugsnag/Report.java
@@ -284,8 +284,7 @@ public class Report {
      * @return the modified report
      */
     public Report setSeverity(Severity severity) {
-        if (severity == null)
-        {
+        if (severity == null) {
             throw new IllegalArgumentException("Severity should not be set to a null value.");
         }
         this.severity = severity;

--- a/bugsnag/src/main/java/com/bugsnag/Report.java
+++ b/bugsnag/src/main/java/com/bugsnag/Report.java
@@ -43,6 +43,9 @@ public class Report {
         this.exception = new Exception(config, throwable);
         this.handledState = handledState;
         this.severity = handledState.getOriginalSeverity();
+        if(this.severity == null) {
+            this.severity = Severity.ERROR;
+        }
         diagnostics = new Diagnostics(this.config);
 
         if (config.sendThreads) {
@@ -281,6 +284,10 @@ public class Report {
      * @return the modified report
      */
     public Report setSeverity(Severity severity) {
+        if(severity == null)
+        {
+            throw new IllegalArgumentException("Severity should not be set to a null value.");
+        }
         this.severity = severity;
         this.handledState.setCurrentSeverity(severity);
         return this;


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
Null severity causing exception during serialization.
`Cannot invoke "com.bugsnag.Severity.getValue()" because "this.severity" is null`

## Design

<!-- Why was this approach used? -->
To check the override for a null severity and log if null = true

## Changeset

<!-- What changed? -->
Added null check to severity value in the Bugsnag.java class for the notify overwrite method.

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->
Running automated tests.