### PR TITLE
added reflection on scheduledtaskrouter to get the errorhandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## Changed
+## TBD
+
+### Changed
+
+* Updated ScheduledTaskConfiguration `configureExistingtaskScheduler` method to support reflect based type-checking for TaskScheduler. [#224](https://github.com/bugsnag/bugsnag-java/pull/224)
+
+## 3.7.2 (2024-08-29)
+
+### Changed
 
 * Add a null check for `Severity` to the notify override method. [#214](https://github.com/bugsnag/bugsnag-java/pull/214)
 


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
To fix warning: 
```com.bugsnag.ScheduledTaskConfiguration   : TaskScheduler of type org.springframework.scheduling.config.TaskSchedulerRouter does not support errorHandler configuration```

## Design

<!-- Why was this approach used? -->
Uses reflection to identify the scheduler's type, supporting both proxied instances and nested delegate schedulers. Tries to ensure error handling by unwrapping TaskSchedulerRouter instances and logging any configuration issues.

## Changeset

<!-- What changed? -->
* updated `configureExistingTaskScheduler` method to support reflection-based type-checking for TaskScheduler.
* Implemented the unwrapRouter method to handle TaskSchedulerRouter instances by accessing the defaultScheduler field.
* Improved logging for better diagnostics during the configuration process.

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->
Tested manually running the example application with the @enabledScheduling annotation.