### PR TITLE
Only use Buildkite plugins once per step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -93,7 +93,6 @@ steps:
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
           cache-from:
             - java-common:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:java-release
-      - docker-compose#v4.7.0:
           push:
             - java-common:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:java-release
 


### PR DESCRIPTION
## Goal

Only use Buildkite plugins once per step, removing a warning that later steps will be ignored in a future version of the agent.

## Testing

Verified by review only - not easily tested in advance of the next release.