### PR TITLE
notifyReleaseStages -> enabledReleaseStages

### DIFF
--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -256,7 +256,7 @@ public class Bugsnag implements Closeable {
      * @param enabledReleaseStages a list of releaseStages to notify for
      * @see #setReleaseStage
      */
-    public void setEnabledReleaseStages(String... enabledReleaseStages) {
+    public void setEnabledReleaseStages(Set<String> enabledReleaseStages) {
         config.enabledReleaseStages = enabledReleaseStages;
     }
 

--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -253,11 +253,11 @@ public class Bugsnag implements Closeable {
      * Set for which releaseStages errors should be sent to Bugsnag.
      * Use this to stop errors from development builds being sent.
      *
-     * @param notifyReleaseStages a list of releaseStages to notify for
+     * @param enabledReleaseStages a list of releaseStages to notify for
      * @see #setReleaseStage
      */
-    public void setNotifyReleaseStages(String... notifyReleaseStages) {
-        config.notifyReleaseStages = notifyReleaseStages;
+    public void setEnabledReleaseStages(String... enabledReleaseStages) {
+        config.enabledReleaseStages = enabledReleaseStages;
     }
 
     /**
@@ -289,7 +289,7 @@ public class Bugsnag implements Closeable {
      * Set the current "release stage" of your application.
      *
      * @param releaseStage the release stage of the app
-     * @see #setNotifyReleaseStages
+     * @see #setEnabledReleaseStages
      */
     public void setReleaseStage(String releaseStage) {
         config.releaseStage = releaseStage;
@@ -302,14 +302,15 @@ public class Bugsnag implements Closeable {
      * environment.
      *
      * @param sendThreads should we send thread state with error reports
-     * @see #setNotifyReleaseStages
+     * @see #setEnabledReleaseStages
      */
     public void setSendThreads(boolean sendThreads) {
         config.sendThreads = sendThreads;
     }
 
     /**
-     * Set a timeout (in ms) to use when delivering Bugsnag error reports and sessions.
+     * Set a timeout (in ms) to use when delivering Bugsnag error reports and
+     * sessions.
      * This is a convenient shorthand for bugsnag.getDelivery().setTimeout();
      *
      * @param timeout the timeout to set (in ms)
@@ -440,9 +441,9 @@ public class Bugsnag implements Closeable {
             return false;
         }
 
-        // Don't notify unless releaseStage is in notifyReleaseStages
+        // Don't notify unless releaseStage is in enabledReleaseStages
         if (!config.shouldNotifyForReleaseStage()) {
-            LOGGER.debug("Error not reported to Bugsnag - {} is not in 'notifyReleaseStages'",
+            LOGGER.debug("Error not reported to Bugsnag - {} is not in 'enabledReleaseStages'",
                     config.releaseStage);
             return false;
         }

--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -256,8 +256,12 @@ public class Bugsnag implements Closeable {
      * @param enabledReleaseStages a list of releaseStages to notify for
      * @see #setReleaseStage
      */
-    public void setEnabledReleaseStages(Set<String> enabledReleaseStages) {
-        config.enabledReleaseStages = enabledReleaseStages;
+    public void setEnabledReleaseStages(String... enabledReleaseStages) {
+        if (enabledReleaseStages == null || enabledReleaseStages.length == 0) {
+            config.enabledReleaseStages = Collections.emptySet();
+        } else {
+            config.enabledReleaseStages = Set.of(enabledReleaseStages);
+        }
     }
 
     /**

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
@@ -254,14 +254,14 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
             bugsnag.setTimeout(timeout);
         }
 
-        if (redactedKeys.size() > 0) {
+        if (!redactedKeys.isEmpty()) {
             bugsnag.setRedactedKeys(redactedKeys.toArray(new String[0]));
         }
 
         bugsnag.setIgnoreClasses(ignoredClasses.toArray(new String[0]));
 
         if (!enabledReleaseStages.isEmpty()) {
-            bugsnag.setEnabledReleaseStages(enabledReleaseStages);
+            bugsnag.setEnabledReleaseStages(enabledReleaseStages.toArray(new String[0]));
         }
 
         bugsnag.setProjectPackages(projectPackages.toArray(new String[0]));
@@ -423,24 +423,24 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     }
 
     /**
-     * @see Bugsnag#setEnabledReleaseStages(Set)
+     * @see Bugsnag#setEnabledReleaseStages(String...)
      */
     public void setEnabledReleaseStage(String enabledReleaseStage) {
         this.enabledReleaseStages.add(enabledReleaseStage);
 
         if (bugsnag != null) {
-            bugsnag.setEnabledReleaseStages(this.enabledReleaseStages);
+            bugsnag.setEnabledReleaseStages(this.enabledReleaseStages.toArray(new String[0]));
         }
     }
 
     /**
-     * @see Bugsnag#setEnabledReleaseStages(Set)
+     * @see Bugsnag#setEnabledReleaseStages(String...)
      */
     public void setEnabledReleaseStages(String enabledReleaseStages) {
         this.enabledReleaseStages.addAll(split(enabledReleaseStages));
 
         if (bugsnag != null) {
-            bugsnag.setEnabledReleaseStages(this.enabledReleaseStages);
+            bugsnag.setEnabledReleaseStages(this.enabledReleaseStages.toArray(new String[0]));
         }
     }
 

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
@@ -417,6 +417,11 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         }
     }
 
+    @Deprecated
+    public void setNotifyReleaseStage(String notifyReleaseStage) {
+        setEnabledReleaseStage(notifyReleaseStage);
+    }
+
     /**
      * @see Bugsnag#setEnabledReleaseStages(String...)
      */

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
@@ -260,14 +260,14 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
         bugsnag.setIgnoreClasses(ignoredClasses.toArray(new String[0]));
 
-        if (enabledReleaseStages.size() > 0) {
-            bugsnag.setEnabledReleaseStages(enabledReleaseStages.toArray(new String[0]));
+        if (!enabledReleaseStages.isEmpty()) {
+            bugsnag.setEnabledReleaseStages(enabledReleaseStages);
         }
 
         bugsnag.setProjectPackages(projectPackages.toArray(new String[0]));
         bugsnag.setSendThreads(sendThreads);
 
-        // Add a callback to put global meta data on every report
+        // Add a callback to put global metadata on every report
         bugsnag.addCallback(new Callback() {
             @Override
             public void beforeNotify(Report report) {
@@ -423,24 +423,24 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     }
 
     /**
-     * @see Bugsnag#setEnabledReleaseStages(String...)
+     * @see Bugsnag#setEnabledReleaseStages(Set)
      */
     public void setEnabledReleaseStage(String enabledReleaseStage) {
         this.enabledReleaseStages.add(enabledReleaseStage);
 
         if (bugsnag != null) {
-            bugsnag.setEnabledReleaseStages(this.enabledReleaseStages.toArray(new String[0]));
+            bugsnag.setEnabledReleaseStages(this.enabledReleaseStages);
         }
     }
 
     /**
-     * @see Bugsnag#setEnabledReleaseStages(String...)
+     * @see Bugsnag#setEnabledReleaseStages(Set)
      */
     public void setEnabledReleaseStages(String enabledReleaseStages) {
         this.enabledReleaseStages.addAll(split(enabledReleaseStages));
 
         if (bugsnag != null) {
-            bugsnag.setEnabledReleaseStages(this.enabledReleaseStages.toArray(new String[0]));
+            bugsnag.setEnabledReleaseStages(this.enabledReleaseStages);
         }
     }
 

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
@@ -55,7 +55,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     private Set<String> ignoredClasses = new HashSet<String>();
 
     /** Release stages that should be notified. */
-    private Set<String> notifyReleaseStages = new HashSet<String>();
+    private Set<String> enabledReleaseStages = new HashSet<String>();
 
     /** Project packages. */
     private Set<String> projectPackages = new HashSet<String>();
@@ -260,8 +260,8 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
         bugsnag.setIgnoreClasses(ignoredClasses.toArray(new String[0]));
 
-        if (notifyReleaseStages.size() > 0) {
-            bugsnag.setNotifyReleaseStages(notifyReleaseStages.toArray(new String[0]));
+        if (enabledReleaseStages.size() > 0) {
+            bugsnag.setEnabledReleaseStages(enabledReleaseStages.toArray(new String[0]));
         }
 
         bugsnag.setProjectPackages(projectPackages.toArray(new String[0]));
@@ -418,24 +418,24 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     }
 
     /**
-     * @see Bugsnag#setNotifyReleaseStages(String...)
+     * @see Bugsnag#setEnabledReleaseStages(String...)
      */
-    public void setNotifyReleaseStage(String notifyReleaseStage) {
-        this.notifyReleaseStages.add(notifyReleaseStage);
+    public void setEnabledReleaseStage(String enabledReleaseStage) {
+        this.enabledReleaseStages.add(enabledReleaseStage);
 
         if (bugsnag != null) {
-            bugsnag.setNotifyReleaseStages(this.notifyReleaseStages.toArray(new String[0]));
+            bugsnag.setEnabledReleaseStages(this.enabledReleaseStages.toArray(new String[0]));
         }
     }
 
     /**
-     * @see Bugsnag#setNotifyReleaseStages(String...)
+     * @see Bugsnag#setEnabledReleaseStages(String...)
      */
-    public void setNotifyReleaseStages(String notifyReleaseStages) {
-        this.notifyReleaseStages.addAll(split(notifyReleaseStages));
+    public void setEnabledReleaseStages(String enabledReleaseStages) {
+        this.enabledReleaseStages.addAll(split(enabledReleaseStages));
 
         if (bugsnag != null) {
-            bugsnag.setNotifyReleaseStages(this.notifyReleaseStages.toArray(new String[0]));
+            bugsnag.setEnabledReleaseStages(this.enabledReleaseStages.toArray(new String[0]));
         }
     }
 

--- a/bugsnag/src/main/java/com/bugsnag/Configuration.java
+++ b/bugsnag/src/main/java/com/bugsnag/Configuration.java
@@ -19,6 +19,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -38,7 +39,7 @@ public class Configuration {
     public Delivery sessionDelivery;
     public String[] redactedKeys = new String[] {"password", "secret", "Authorization", "Cookie"};
     public String[] ignoreClasses;
-    public String[] enabledReleaseStages = null;
+    public Set<String> enabledReleaseStages = null;
     public String[] projectPackages;
     public String releaseStage;
     public boolean sendThreads = false;
@@ -69,9 +70,7 @@ public class Configuration {
         if (enabledReleaseStages == null) {
             return true;
         }
-
-        List<String> stages = Arrays.asList(enabledReleaseStages);
-        return stages.contains(releaseStage);
+        return enabledReleaseStages.contains(releaseStage);
     }
 
     boolean shouldIgnoreClass(String className) {

--- a/bugsnag/src/main/java/com/bugsnag/Configuration.java
+++ b/bugsnag/src/main/java/com/bugsnag/Configuration.java
@@ -36,9 +36,9 @@ public class Configuration {
     public Delivery delivery;
     public EndpointConfiguration endpointConfiguration;
     public Delivery sessionDelivery;
-    public String[] redactedKeys = new String[]{"password", "secret", "Authorization", "Cookie"};
+    public String[] redactedKeys = new String[] { "password", "secret", "Authorization", "Cookie" };
     public String[] ignoreClasses;
-    public String[] notifyReleaseStages = null;
+    public String[] enabledReleaseStages = null;
     public String[] projectPackages;
     public String releaseStage;
     public boolean sendThreads = false;
@@ -66,11 +66,11 @@ public class Configuration {
     }
 
     boolean shouldNotifyForReleaseStage() {
-        if (notifyReleaseStages == null) {
+        if (enabledReleaseStages == null) {
             return true;
         }
 
-        List<String> stages = Arrays.asList(notifyReleaseStages);
+        List<String> stages = Arrays.asList(enabledReleaseStages);
         return stages.contains(releaseStage);
     }
 

--- a/bugsnag/src/main/java/com/bugsnag/Configuration.java
+++ b/bugsnag/src/main/java/com/bugsnag/Configuration.java
@@ -36,7 +36,7 @@ public class Configuration {
     public Delivery delivery;
     public EndpointConfiguration endpointConfiguration;
     public Delivery sessionDelivery;
-    public String[] redactedKeys = new String[] { "password", "secret", "Authorization", "Cookie" };
+    public String[] redactedKeys = new String[] {"password", "secret", "Authorization", "Cookie"};
     public String[] ignoreClasses;
     public String[] enabledReleaseStages = null;
     public String[] projectPackages;

--- a/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
@@ -150,20 +150,17 @@ public class AppenderTest {
         assertTrue(redactedKeys.contains("credit_card_number"));
 
         assertEquals(2, config.ignoreClasses.length);
-        ArrayList<String> ignoreClasses
-                = new ArrayList<String>(Arrays.asList(config.ignoreClasses));
+        ArrayList<String> ignoreClasses = new ArrayList<String>(Arrays.asList(config.ignoreClasses));
         assertTrue(ignoreClasses.contains("com.example.Custom"));
         assertTrue(ignoreClasses.contains("java.io.IOException"));
 
-        assertEquals(2, config.notifyReleaseStages.length);
-        ArrayList<String> notifyReleaseStages
-                = new ArrayList<String>(Arrays.asList(config.notifyReleaseStages));
-        assertTrue(notifyReleaseStages.contains("development"));
-        assertTrue(notifyReleaseStages.contains("test"));
+        assertEquals(2, config.enabledReleaseStages.length);
+        ArrayList<String> enabledReleaseStages = new ArrayList<String>(Arrays.asList(config.enabledReleaseStages));
+        assertTrue(enabledReleaseStages.contains("development"));
+        assertTrue(enabledReleaseStages.contains("test"));
 
         assertEquals(2, config.projectPackages.length);
-        ArrayList<String> projectPackages
-                = new ArrayList<String>(Arrays.asList(config.projectPackages));
+        ArrayList<String> projectPackages = new ArrayList<String>(Arrays.asList(config.projectPackages));
         assertTrue(projectPackages.contains("com.company.package2"));
         assertTrue(projectPackages.contains("com.company.package1"));
 
@@ -208,7 +205,7 @@ public class AppenderTest {
     }
 
     @Test
-    public void testNotifyReleaseStages() {
+    public void testEnabledReleaseStages() {
         // Send a log with the release stage set to an excluded one
         appender.setReleaseStage("ignoredReleaseStage");
         LOGGER.warn("Release stage ignored", new RuntimeException("test"));

--- a/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
@@ -154,10 +154,9 @@ public class AppenderTest {
         assertTrue(ignoreClasses.contains("com.example.Custom"));
         assertTrue(ignoreClasses.contains("java.io.IOException"));
 
-        assertEquals(2, config.enabledReleaseStages.length);
-        ArrayList<String> enabledReleaseStages = new ArrayList<String>(Arrays.asList(config.enabledReleaseStages));
-        assertTrue(enabledReleaseStages.contains("development"));
-        assertTrue(enabledReleaseStages.contains("test"));
+        assertEquals(2, config.enabledReleaseStages.size());
+        assertTrue(config.enabledReleaseStages.contains("development"));
+        assertTrue(config.enabledReleaseStages.contains("test"));
 
         assertEquals(2, config.projectPackages.length);
         ArrayList<String> projectPackages = new ArrayList<String>(Arrays.asList(config.projectPackages));

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
@@ -73,25 +73,25 @@ public class BugsnagTest {
     }
 
     @Test
-    public void testNotifyReleaseStages() {
+    public void testEnabledReleaseStages() {
         bugsnag.setDelivery(BugsnagTestUtils.generateDelivery());
 
         bugsnag.setReleaseStage("production");
 
         // Never send
-        bugsnag.setNotifyReleaseStages();
+        bugsnag.setEnabledReleaseStages();
         assertFalse(bugsnag.notify(new Throwable()));
 
         // Ignore 'production'
-        bugsnag.setNotifyReleaseStages("staging", "development");
+        bugsnag.setEnabledReleaseStages("staging", "development");
         assertFalse(bugsnag.notify(new Throwable()));
 
         // Allow 'production'
-        bugsnag.setNotifyReleaseStages("production");
+        bugsnag.setEnabledReleaseStages("production");
         assertTrue(bugsnag.notify(new Throwable()));
 
         // Allow 'production' and others
-        bugsnag.setNotifyReleaseStages("production", "staging", "development");
+        bugsnag.setEnabledReleaseStages("production", "staging", "development");
         assertTrue(bugsnag.notify(new Throwable()));
     }
 

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
@@ -21,9 +21,7 @@ import java.io.ByteArrayOutputStream;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -82,19 +80,19 @@ public class BugsnagTest {
         bugsnag.setReleaseStage("production");
 
         // Never send
-        bugsnag.setEnabledReleaseStages(new HashSet<>());
+        bugsnag.setEnabledReleaseStages();
         assertFalse(bugsnag.notify(new Throwable()));
 
         // Ignore 'production'
-        bugsnag.setEnabledReleaseStages(Collections.singleton("staging"));
+        bugsnag.setEnabledReleaseStages("staging");
         assertFalse(bugsnag.notify(new Throwable()));
 
         // Allow 'production'
-        bugsnag.setEnabledReleaseStages(Collections.singleton("production"));
+        bugsnag.setEnabledReleaseStages("production");
         assertTrue(bugsnag.notify(new Throwable()));
 
         // Allow 'production' and others
-        bugsnag.setEnabledReleaseStages(Collections.singleton("production"));
+        bugsnag.setEnabledReleaseStages("production");
         assertTrue(bugsnag.notify(new Throwable()));
     }
 

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
@@ -17,12 +17,15 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
+
 import java.net.InetSocketAddress;
 import java.net.Proxy;
+
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
 
 public class BugsnagTest {
 
@@ -79,19 +82,19 @@ public class BugsnagTest {
         bugsnag.setReleaseStage("production");
 
         // Never send
-        bugsnag.setEnabledReleaseStages();
+        bugsnag.setEnabledReleaseStages(new HashSet<>());
         assertFalse(bugsnag.notify(new Throwable()));
 
         // Ignore 'production'
-        bugsnag.setEnabledReleaseStages("staging", "development");
+        bugsnag.setEnabledReleaseStages(Collections.singleton("staging"));
         assertFalse(bugsnag.notify(new Throwable()));
 
         // Allow 'production'
-        bugsnag.setEnabledReleaseStages("production");
+        bugsnag.setEnabledReleaseStages(Collections.singleton("production"));
         assertTrue(bugsnag.notify(new Throwable()));
 
         // Allow 'production' and others
-        bugsnag.setEnabledReleaseStages("production", "staging", "development");
+        bugsnag.setEnabledReleaseStages(Collections.singleton("production"));
         assertTrue(bugsnag.notify(new Throwable()));
     }
 

--- a/bugsnag/src/test/java/com/bugsnag/SessionTrackerTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/SessionTrackerTest.java
@@ -133,7 +133,7 @@ public class SessionTrackerTest {
 
     @Test
     public void disabledReleaseStage() {
-        configuration.notifyReleaseStages = new String[]{"prod"};
+        configuration.enabledReleaseStages = new String[] { "prod" };
         configuration.releaseStage = "dev";
         sessionTracker.startSession(new Date(), false);
         assertNull(sessionTracker.getSession());
@@ -141,7 +141,7 @@ public class SessionTrackerTest {
 
     @Test
     public void enabledReleaseStage() {
-        configuration.notifyReleaseStages = new String[]{"prod"};
+        configuration.enabledReleaseStages = new String[] { "prod" };
         configuration.releaseStage = "prod";
         sessionTracker.startSession(new Date(), false);
         assertNotNull(sessionTracker.getSession());

--- a/bugsnag/src/test/java/com/bugsnag/SessionTrackerTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/SessionTrackerTest.java
@@ -133,7 +133,7 @@ public class SessionTrackerTest {
 
     @Test
     public void disabledReleaseStage() {
-        configuration.enabledReleaseStages = new String[] { "prod" };
+        configuration.enabledReleaseStages = new String[] {"prod"};
         configuration.releaseStage = "dev";
         sessionTracker.startSession(new Date(), false);
         assertNull(sessionTracker.getSession());
@@ -141,7 +141,7 @@ public class SessionTrackerTest {
 
     @Test
     public void enabledReleaseStage() {
-        configuration.enabledReleaseStages = new String[] { "prod" };
+        configuration.enabledReleaseStages = new String[] {"prod"};
         configuration.releaseStage = "prod";
         sessionTracker.startSession(new Date(), false);
         assertNotNull(sessionTracker.getSession());

--- a/bugsnag/src/test/java/com/bugsnag/SessionTrackerTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/SessionTrackerTest.java
@@ -14,6 +14,7 @@ import com.bugsnag.serialization.Serializer;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -133,7 +134,7 @@ public class SessionTrackerTest {
 
     @Test
     public void disabledReleaseStage() {
-        configuration.enabledReleaseStages = new String[] {"prod"};
+        configuration.enabledReleaseStages = Collections.singleton("prod");
         configuration.releaseStage = "dev";
         sessionTracker.startSession(new Date(), false);
         assertNull(sessionTracker.getSession());
@@ -141,7 +142,7 @@ public class SessionTrackerTest {
 
     @Test
     public void enabledReleaseStage() {
-        configuration.enabledReleaseStages = new String[] {"prod"};
+        configuration.enabledReleaseStages = Collections.singleton("prod");
         configuration.releaseStage = "prod";
         sessionTracker.startSession(new Date(), false);
         assertNotNull(sessionTracker.getSession());

--- a/bugsnag/src/test/resources/logback.xml
+++ b/bugsnag/src/test/resources/logback.xml
@@ -13,8 +13,8 @@
         <ignoredClass>java.io.IOException</ignoredClass>
         <ignoredClass>com.example.Custom</ignoredClass>
 
-        <notifyReleaseStage>test</notifyReleaseStage>
-        <notifyReleaseStage>development</notifyReleaseStage>
+        <enabledReleaseStage>test</enabledReleaseStage>
+        <enabledReleaseStage>development</enabledReleaseStage>
 
         <projectPackage>com.company.package1</projectPackage>
         <projectPackage>com.company.package2</projectPackage>

--- a/examples/logback/src/main/resources/logback.xml
+++ b/examples/logback/src/main/resources/logback.xml
@@ -23,8 +23,8 @@
         <!--<ignoredClass>java.io.IOException</ignoredClass>-->
         <!--<ignoredClass>com.example.Custom</ignoredClass>-->
 
-        <!--<notifyReleaseStage>production</notifyReleaseStage>-->
-        <!--<notifyReleaseStage>development</notifyReleaseStage>-->
+        <!--<enabledReleaseStage>production</enabledReleaseStage>-->
+        <!--<enabledReleaseStage>development</enabledReleaseStage>-->
 
         <!--<projectPackage>com.company.package1</projectPackage>-->
         <!--<projectPackage>com.company.package2</projectPackage>-->

--- a/features/fixtures/logback/ignore_release_stage_config.xml
+++ b/features/fixtures/logback/ignore_release_stage_config.xml
@@ -7,8 +7,8 @@
         <releaseStage>staging</releaseStage>
         <appVersion>1.0.0</appVersion>
 
-		<notifyReleaseStage>production</notifyReleaseStage>
-		<notifyReleaseStage>development</notifyReleaseStage>
+		<enabledReleaseStage>production</enabledReleaseStage>
+		<enabledReleaseStage>development</enabledReleaseStage>
 
 		<endpoint>http://localhost:9339/notify</endpoint>
 	</appender>

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ArrayNotifyReleaseStageScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ArrayNotifyReleaseStageScenario.java
@@ -14,7 +14,7 @@ public class ArrayNotifyReleaseStageScenario extends Scenario {
     @Override
     public void run() {
         bugsnag.setReleaseStage("prod");
-        bugsnag.setNotifyReleaseStages("dev", "prod");
+        bugsnag.setEnabledReleaseStages("dev", "prod");
         bugsnag.notify(generateException());
     }
 }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/InsideReleaseStageScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/InsideReleaseStageScenario.java
@@ -14,7 +14,7 @@ public class InsideReleaseStageScenario extends Scenario {
     @Override
     public void run() {
         bugsnag.setReleaseStage("prod");
-        bugsnag.setNotifyReleaseStages("prod");
+        bugsnag.setEnabledReleaseStages("prod");
         bugsnag.notify(generateException());
     }
 }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/NullNotifyReleaseStageScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/NullNotifyReleaseStageScenario.java
@@ -3,7 +3,8 @@ package com.bugsnag.mazerunner.scenarios;
 import com.bugsnag.Bugsnag;
 
 /**
- * Attempts to send a handled exception to Bugsnag, when the notifyReleaseStages is null.
+ * Attempts to send a handled exception to Bugsnag, when the
+ * enabledReleaseStages is null.
  */
 public class NullNotifyReleaseStageScenario extends Scenario {
 

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/NullReleaseStageScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/NullReleaseStageScenario.java
@@ -14,7 +14,7 @@ public class NullReleaseStageScenario extends Scenario {
     @Override
     public void run() {
         bugsnag.setReleaseStage(null);
-        bugsnag.setNotifyReleaseStages("dev");
+        bugsnag.setEnabledReleaseStages("dev");
         bugsnag.notify(generateException());
     }
 }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/OutsideReleaseStageScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/OutsideReleaseStageScenario.java
@@ -15,7 +15,7 @@ public class OutsideReleaseStageScenario extends Scenario {
     @Override
     public void run() {
         bugsnag.setReleaseStage("prod");
-        bugsnag.setNotifyReleaseStages("dev");
+        bugsnag.setEnabledReleaseStages("dev");
         bugsnag.notify(generateException());
     }
 }


### PR DESCRIPTION
This pull request refactors the configuration option for specifying which release stages should send errors to Bugsnag. The property and related methods have been renamed from `notifyReleaseStages` to `enabledReleaseStages` throughout the codebase, including classes, methods, documentation, tests, and configuration files. This change improves clarity and consistency in naming, making it easier to understand the intent of the setting.

**API and Configuration Refactor**

* Renamed the configuration property in `Configuration` from `notifyReleaseStages` to `enabledReleaseStages`, and updated all related logic to use the new name. [[1]](diffhunk://#diff-40b0aec908d036acb0640964f280be9666de2f2a95a99b20aac63f63306ea558L41-R41) [[2]](diffhunk://#diff-40b0aec908d036acb0640964f280be9666de2f2a95a99b20aac63f63306ea558L69-R73)
* Updated the `Bugsnag` and `BugsnagAppender` classes: methods, fields, and documentation now use `enabledReleaseStages` instead of `notifyReleaseStages`. Deprecated old setter methods and added new ones for the updated naming. [[1]](diffhunk://#diff-6ad713252a342f0f5deb3f951b62cf1522529c9a571d3c1e2bc8864eac5aebe4L256-R260) [[2]](diffhunk://#diff-456413ca4e20af5151ea089cfd5e6f72c4b9cece6e32e392fec6e9876dd969b1L58-R58) [[3]](diffhunk://#diff-456413ca4e20af5151ea089cfd5e6f72c4b9cece6e32e392fec6e9876dd969b1L263-R264) [[4]](diffhunk://#diff-456413ca4e20af5151ea089cfd5e6f72c4b9cece6e32e392fec6e9876dd969b1R420-R443) [[5]](diffhunk://#diff-6ad713252a342f0f5deb3f951b62cf1522529c9a571d3c1e2bc8864eac5aebe4L292-R292) [[6]](diffhunk://#diff-6ad713252a342f0f5deb3f951b62cf1522529c9a571d3c1e2bc8864eac5aebe4L305-R313) [[7]](diffhunk://#diff-6ad713252a342f0f5deb3f951b62cf1522529c9a571d3c1e2bc8864eac5aebe4L443-R446)

**Test and Scenario Updates**

* Refactored all tests and scenario classes to use `enabledReleaseStages` instead of `notifyReleaseStages`, including method names, assertions, and comments. [[1]](diffhunk://#diff-8612121969fc2a84733fdc572d983670cd4296dd926deecc565d3c423830de32L153-R163) [[2]](diffhunk://#diff-8612121969fc2a84733fdc572d983670cd4296dd926deecc565d3c423830de32L211-R208) [[3]](diffhunk://#diff-e0a0e1a938dff6c7a2b4afa1b3ae7f130410e6cf264b254b831e5f981eb57acaL76-R94) [[4]](diffhunk://#diff-91655a5af9acf00e0d43c20fdc30654ee15e8a88fec227781d29c474336ce4a4L136-R144) [[5]](diffhunk://#diff-ed5e556425c912ce70e73a86bd7c29ddf658632504e19f638740b6e05a97813bL17-R17) [[6]](diffhunk://#diff-d3bbbd261b57913e0c9e36ce79a7c9747f2c0b15b4109593f899df05a14efb9cL17-R17) [[7]](diffhunk://#diff-18d1ac6c572a2370b2f505e1e5e7578f1c10f98f8ae9e7abc1d88cb53bd7c9b7L6-R7) [[8]](diffhunk://#diff-6e0e1ee4487c17bcb149fee684a74e0ed24ec66917ebfde1121e5e5742e9933bL17-R17) [[9]](diffhunk://#diff-8abb41208a1dbe1e99ed52f5e1a6550b67df5407b01f62702c6dbcea6984ca5eL18-R18)

**Configuration File Changes**

* Updated XML configuration files to use `<enabledReleaseStage>` tags instead of `<notifyReleaseStage>`. [[1]](diffhunk://#diff-dfa998223ce7bd1a0eeb18b33c19e0c99abbee84e08783e8f1ed90a88d3e8e0eL16-R17) [[2]](diffhunk://#diff-c8d302a1a3bfc8dbfdc6a127d420073bb972ec56eb65091f7e80e2bcd47b775bL26-R27) [[3]](diffhunk://#diff-abe0d9da50fdc9b27433fb4c7543f3e1052f8e3b50dcbe7cad4a72222df6fbd3L10-R11)