### PR TITLE
rename ignoreClasses to discardClasses

### DIFF
--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -243,10 +243,10 @@ public class Bugsnag implements Closeable {
     /**
      * Set which exception classes should be ignored (not sent) by Bugsnag.
      *
-     * @param ignoreClasses a list of exception classes to ignore
+     * @param discardClasses a list of exception classes to ignore
      */
-    public void setIgnoreClasses(String... ignoreClasses) {
-        config.ignoreClasses = ignoreClasses;
+    public void setDiscardClasses(String... discardClasses) {
+        config.discardClasses = discardClasses;
     }
 
     /**
@@ -440,7 +440,7 @@ public class Bugsnag implements Closeable {
 
         // Don't notify if this error class should be ignored
         if (config.shouldIgnoreClass(report.getExceptionName())) {
-            LOGGER.debug("Error not reported to Bugsnag - {} is in 'ignoreClasses'",
+            LOGGER.debug("Error not reported to Bugsnag - {} is in 'discardClasses'",
                     report.getExceptionName());
             return false;
         }

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
@@ -52,7 +52,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     private Set<String> redactedKeys = new HashSet<String>();
 
     /** Exception classes to be ignored. */
-    private Set<String> ignoredClasses = new HashSet<String>();
+    private Set<String> discardClasses = new HashSet<String>();
 
     /** Release stages that should be notified. */
     private Set<String> enabledReleaseStages = new HashSet<String>();
@@ -258,7 +258,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
             bugsnag.setRedactedKeys(redactedKeys.toArray(new String[0]));
         }
 
-        bugsnag.setDiscardClasses(ignoredClasses.toArray(new String[0]));
+        bugsnag.setDiscardClasses(discardClasses.toArray(new String[0]));
 
         if (!enabledReleaseStages.isEmpty()) {
             bugsnag.setEnabledReleaseStages(enabledReleaseStages.toArray(new String[0]));
@@ -395,25 +395,30 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         }
     }
 
+    @Deprecated
+    public void setIgnoredClass(String ignoredClass) {
+        setDiscardClass(ignoredClass);
+    }
+
     /**
      * @see Bugsnag#setDiscardClasses(String...)
      */
-    public void setIgnoredClass(String ignoredClass) {
-        this.ignoredClasses.add(ignoredClass);
+    public void setDiscardClass(String discardClass) {
+        this.discardClasses.add(discardClass);
 
         if (bugsnag != null) {
-            bugsnag.setDiscardClasses(this.ignoredClasses.toArray(new String[0]));
+            bugsnag.setDiscardClasses(this.discardClasses.toArray(new String[0]));
         }
     }
 
     /**
      * @see Bugsnag#setDiscardClasses(String...)
      */
-    public void setIgnoredClasses(String ignoredClasses) {
-        this.ignoredClasses.addAll(split(ignoredClasses));
+    public void setDiscardClasses(String discardClasses) {
+        this.discardClasses.addAll(split(discardClasses));
 
         if (bugsnag != null) {
-            bugsnag.setDiscardClasses(this.ignoredClasses.toArray(new String[0]));
+            bugsnag.setDiscardClasses(this.discardClasses.toArray(new String[0]));
         }
     }
 

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
@@ -258,7 +258,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
             bugsnag.setRedactedKeys(redactedKeys.toArray(new String[0]));
         }
 
-        bugsnag.setIgnoreClasses(ignoredClasses.toArray(new String[0]));
+        bugsnag.setDiscardClasses(ignoredClasses.toArray(new String[0]));
 
         if (!enabledReleaseStages.isEmpty()) {
             bugsnag.setEnabledReleaseStages(enabledReleaseStages.toArray(new String[0]));
@@ -396,24 +396,24 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     }
 
     /**
-     * @see Bugsnag#setIgnoreClasses(String...)
+     * @see Bugsnag#setDiscardClasses(String...)
      */
     public void setIgnoredClass(String ignoredClass) {
         this.ignoredClasses.add(ignoredClass);
 
         if (bugsnag != null) {
-            bugsnag.setIgnoreClasses(this.ignoredClasses.toArray(new String[0]));
+            bugsnag.setDiscardClasses(this.ignoredClasses.toArray(new String[0]));
         }
     }
 
     /**
-     * @see Bugsnag#setIgnoreClasses(String...)
+     * @see Bugsnag#setDiscardClasses(String...)
      */
     public void setIgnoredClasses(String ignoredClasses) {
         this.ignoredClasses.addAll(split(ignoredClasses));
 
         if (bugsnag != null) {
-            bugsnag.setIgnoreClasses(this.ignoredClasses.toArray(new String[0]));
+            bugsnag.setDiscardClasses(this.ignoredClasses.toArray(new String[0]));
         }
     }
 

--- a/bugsnag/src/main/java/com/bugsnag/Configuration.java
+++ b/bugsnag/src/main/java/com/bugsnag/Configuration.java
@@ -38,7 +38,7 @@ public class Configuration {
     public EndpointConfiguration endpointConfiguration;
     public Delivery sessionDelivery;
     public String[] redactedKeys = new String[] {"password", "secret", "Authorization", "Cookie"};
-    public String[] ignoreClasses;
+    public String[] discardClasses;
     public Set<String> enabledReleaseStages = null;
     public String[] projectPackages;
     public String releaseStage;
@@ -74,11 +74,11 @@ public class Configuration {
     }
 
     boolean shouldIgnoreClass(String className) {
-        if (ignoreClasses == null) {
+        if (discardClasses == null) {
             return false;
         }
 
-        List<String> classes = Arrays.asList(ignoreClasses);
+        List<String> classes = Arrays.asList(discardClasses);
         return classes.contains(className);
     }
 

--- a/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
@@ -149,10 +149,10 @@ public class AppenderTest {
         assertTrue(redactedKeys.contains("password"));
         assertTrue(redactedKeys.contains("credit_card_number"));
 
-        assertEquals(2, config.ignoreClasses.length);
-        ArrayList<String> ignoreClasses = new ArrayList<String>(Arrays.asList(config.ignoreClasses));
-        assertTrue(ignoreClasses.contains("com.example.Custom"));
-        assertTrue(ignoreClasses.contains("java.io.IOException"));
+        assertEquals(2, config.discardClasses.length);
+        ArrayList<String> discardClasses = new ArrayList<String>(Arrays.asList(config.discardClasses));
+        assertTrue(discardClasses.contains("com.example.Custom"));
+        assertTrue(discardClasses.contains("java.io.IOException"));
 
         assertEquals(2, config.enabledReleaseStages.size());
         assertTrue(config.enabledReleaseStages.contains("development"));

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
@@ -58,17 +58,17 @@ public class BugsnagTest {
         bugsnag.setDelivery(BugsnagTestUtils.generateDelivery());
 
         // Ignore neither
-        bugsnag.setIgnoreClasses();
+        bugsnag.setDiscardClasses();
         assertTrue(bugsnag.notify(new RuntimeException()));
         assertTrue(bugsnag.notify(new TestException()));
 
         // Ignore just RuntimeException
-        bugsnag.setIgnoreClasses(RuntimeException.class.getName());
+        bugsnag.setDiscardClasses(RuntimeException.class.getName());
         assertFalse(bugsnag.notify(new RuntimeException()));
         assertTrue(bugsnag.notify(new TestException()));
 
         // Ignore both
-        bugsnag.setIgnoreClasses(RuntimeException.class.getName(), TestException.class.getName());
+        bugsnag.setDiscardClasses(RuntimeException.class.getName(), TestException.class.getName());
         assertFalse(bugsnag.notify(new RuntimeException()));
         assertFalse(bugsnag.notify(new TestException()));
     }

--- a/bugsnag/src/test/resources/logback.xml
+++ b/bugsnag/src/test/resources/logback.xml
@@ -10,8 +10,8 @@
         <redactedKey>password</redactedKey>
         <redactedKey>credit_card_number</redactedKey>
 
-        <ignoredClass>java.io.IOException</ignoredClass>
-        <ignoredClass>com.example.Custom</ignoredClass>
+        <discardClass>java.io.IOException</discardClass>
+        <discardClass>com.example.Custom</discardClass>
 
         <enabledReleaseStage>test</enabledReleaseStage>
         <enabledReleaseStage>development</enabledReleaseStage>

--- a/examples/logback/src/main/resources/logback.xml
+++ b/examples/logback/src/main/resources/logback.xml
@@ -20,8 +20,8 @@
         <!--<redactedKey>password</redactedKey>-->
         <!--<redactedKey>credit_card_number</redactedKey>-->
 
-        <!--<ignoredClass>java.io.IOException</ignoredClass>-->
-        <!--<ignoredClass>com.example.Custom</ignoredClass>-->
+        <!--<discardClass>java.io.IOException</discardClass>-->
+        <!--<discardClass>com.example.Custom</discardClass>-->
 
         <!--<enabledReleaseStage>production</enabledReleaseStage>-->
         <!--<enabledReleaseStage>development</enabledReleaseStage>-->

--- a/features/fixtures/logback/ignored_class_config.xml
+++ b/features/fixtures/logback/ignored_class_config.xml
@@ -7,7 +7,7 @@
         <releaseStage>production</releaseStage>
         <appVersion>1.0.0</appVersion>
 
-		<ignoredClass>java.lang.RuntimeException</ignoredClass>
+		<discardClass>java.lang.RuntimeException</discardClass>
 
 		<endpoint>http://localhost:9339/notify</endpoint>
 	</appender>

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/IgnoredExceptionScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/IgnoredExceptionScenario.java
@@ -15,7 +15,7 @@ public class IgnoredExceptionScenario extends Scenario {
     @Override
     public void run() {
 
-        bugsnag.setIgnoreClasses("java.lang.RuntimeException");
+        bugsnag.setDiscardClasses("java.lang.RuntimeException");
 
         bugsnag.notify(new RuntimeException("Should never appear"));
     }


### PR DESCRIPTION
rename ignoreClasses to discardClasses

### Refactoring: Terminology Change from "Ignore" to "Discard"

* Renamed all references of `ignoreClasses` to `discardClasses` in the main configuration (`Configuration.java`), the Bugsnag client (`Bugsnag.java`), and the appender (`BugsnagAppender.java`). This includes method names, variable names, and internal logic. [[1]](diffhunk://#diff-6ad713252a342f0f5deb3f951b62cf1522529c9a571d3c1e2bc8864eac5aebe4L246-R249) [[2]](diffhunk://#diff-456413ca4e20af5151ea089cfd5e6f72c4b9cece6e32e392fec6e9876dd969b1L55-R55) [[3]](diffhunk://#diff-40b0aec908d036acb0640964f280be9666de2f2a95a99b20aac63f63306ea558L41-R41)
* Updated the logic that determines whether an exception class should be reported, now checking `discardClasses` instead of `ignoreClasses`.
* Updated all related logging messages and documentation comments to use "discard" terminology. [[1]](diffhunk://#diff-6ad713252a342f0f5deb3f951b62cf1522529c9a571d3c1e2bc8864eac5aebe4L443-R443) [[2]](diffhunk://#diff-456413ca4e20af5151ea089cfd5e6f72c4b9cece6e32e392fec6e9876dd969b1R398-R421)

### Backward Compatibility

* Added deprecated methods (`setIgnoredClass`) in `BugsnagAppender.java` that delegate to the new `setDiscardClass` methods, ensuring existing integrations do not break.

