### PR TITLE
rename callbacks and update functionality

### DIFF
--- a/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
@@ -28,8 +28,9 @@ public class BugsnagSpringConfiguration implements InitializingBean {
     Callback springVersionErrorCallback() {
         Callback callback = new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 addSpringRuntimeVersion(report.getDevice());
+                return true;
             }
         };
         bugsnag.addCallback(callback);

--- a/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
@@ -37,15 +37,15 @@ public class BugsnagSpringConfiguration implements InitializingBean {
     }
 
     @Bean
-    BeforeSendSession springVersionSessionCallback() {
-        BeforeSendSession beforeSendSession = new BeforeSendSession() {
+    OnSession springVersionSessionCallback() {
+        OnSession onSession = new OnSession() {
             @Override
             public void onSession(SessionPayload payload) {
                 addSpringRuntimeVersion(payload.getDevice());
             }
         };
-        bugsnag.addBeforeSendSession(beforeSendSession);
-        return beforeSendSession;
+        bugsnag.addOnSession(onSession);
+        return onSession;
     }
 
     private void addSpringRuntimeVersion(Map<String, Object> device) {

--- a/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
@@ -40,7 +40,7 @@ public class BugsnagSpringConfiguration implements InitializingBean {
     BeforeSendSession springVersionSessionCallback() {
         BeforeSendSession beforeSendSession = new BeforeSendSession() {
             @Override
-            public void beforeSendSession(SessionPayload payload) {
+            public void onSession(SessionPayload payload) {
                 addSpringRuntimeVersion(payload.getDevice());
             }
         };

--- a/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
@@ -40,8 +40,9 @@ public class BugsnagSpringConfiguration implements InitializingBean {
     OnSession springVersionSessionCallback() {
         OnSession onSession = new OnSession() {
             @Override
-            public void onSession(SessionPayload payload) {
+            public Boolean onSession(SessionPayload payload) {
                 addSpringRuntimeVersion(payload.getDevice());
+                return true;
             }
         };
         bugsnag.addOnSession(onSession);

--- a/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
@@ -28,7 +28,7 @@ public class BugsnagSpringConfiguration implements InitializingBean {
     Callback springVersionErrorCallback() {
         Callback callback = new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 addSpringRuntimeVersion(report.getDevice());
             }
         };

--- a/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
@@ -28,7 +28,7 @@ public class BugsnagSpringConfiguration implements InitializingBean {
     Callback springVersionErrorCallback() {
         Callback callback = new Callback() {
             @Override
-            public Boolean onError(Report report) {
+            public boolean onError(Report report) {
                 addSpringRuntimeVersion(report.getDevice());
                 return true;
             }
@@ -41,7 +41,7 @@ public class BugsnagSpringConfiguration implements InitializingBean {
     OnSession springVersionSessionCallback() {
         OnSession onSession = new OnSession() {
             @Override
-            public Boolean onSession(SessionPayload payload) {
+            public boolean onSession(SessionPayload payload) {
                 addSpringRuntimeVersion(payload.getDevice());
                 return true;
             }

--- a/bugsnag-spring/src/main/java/com/bugsnag/ExceptionClassCallback.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/ExceptionClassCallback.java
@@ -111,7 +111,7 @@ class ExceptionClassCallback implements Callback {
     }
 
     @Override
-    public void beforeNotify(Report report) {
+    public void onError(Report report) {
 
         HandledState handledState = report.getHandledState();
 

--- a/bugsnag-spring/src/main/java/com/bugsnag/ExceptionClassCallback.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/ExceptionClassCallback.java
@@ -111,7 +111,7 @@ class ExceptionClassCallback implements Callback {
     }
 
     @Override
-    public void onError(Report report) {
+    public Boolean onError(Report report) {
 
         HandledState handledState = report.getHandledState();
 
@@ -119,7 +119,7 @@ class ExceptionClassCallback implements Callback {
         SeverityReasonType severityReasonType = handledState.calculateSeverityReasonType();
         if (severityReasonType == SeverityReasonType.REASON_USER_SPECIFIED
                 || severityReasonType == SeverityReasonType.REASON_CALLBACK_SPECIFIED) {
-            return;
+            return true; // do not change delivery decision
         }
 
         Class exceptionClass = report.getException().getClass();
@@ -133,5 +133,6 @@ class ExceptionClassCallback implements Callback {
                     severity,
                     handledState.isUnhandled()));
         }
+        return true;
     }
 }

--- a/bugsnag-spring/src/main/java/com/bugsnag/ExceptionClassCallback.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/ExceptionClassCallback.java
@@ -111,7 +111,7 @@ class ExceptionClassCallback implements Callback {
     }
 
     @Override
-    public Boolean onError(Report report) {
+    public boolean onError(Report report) {
 
         HandledState handledState = report.getHandledState();
 

--- a/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
@@ -19,8 +19,9 @@ public class SpringBootConfiguration {
     Callback springBootVersionErrorCallback() {
         Callback callback = new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 addSpringRuntimeVersion(report.getDevice());
+                return true;
             }
         };
         bugsnag.addCallback(callback);

--- a/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
@@ -28,15 +28,15 @@ public class SpringBootConfiguration {
     }
 
     @Bean
-    BeforeSendSession springBootVersionSessionCallback() {
-        BeforeSendSession beforeSendSession = new BeforeSendSession() {
+    OnSession springBootVersionSessionCallback() {
+        OnSession onSession = new OnSession() {
             @Override
             public void onSession(SessionPayload payload) {
                 addSpringRuntimeVersion(payload.getDevice());
             }
         };
-        bugsnag.addBeforeSendSession(beforeSendSession);
-        return beforeSendSession;
+        bugsnag.addOnSession(onSession);
+        return onSession;
     }
 
     private void addSpringRuntimeVersion(Map<String, Object> device) {

--- a/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
@@ -19,7 +19,7 @@ public class SpringBootConfiguration {
     Callback springBootVersionErrorCallback() {
         Callback callback = new Callback() {
             @Override
-            public Boolean onError(Report report) {
+            public boolean onError(Report report) {
                 addSpringRuntimeVersion(report.getDevice());
                 return true;
             }
@@ -32,7 +32,7 @@ public class SpringBootConfiguration {
     OnSession springBootVersionSessionCallback() {
         OnSession onSession = new OnSession() {
             @Override
-            public Boolean onSession(SessionPayload payload) {
+            public boolean onSession(SessionPayload payload) {
                 addSpringRuntimeVersion(payload.getDevice());
                 return true;
             }

--- a/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
@@ -31,7 +31,7 @@ public class SpringBootConfiguration {
     BeforeSendSession springBootVersionSessionCallback() {
         BeforeSendSession beforeSendSession = new BeforeSendSession() {
             @Override
-            public void beforeSendSession(SessionPayload payload) {
+            public void onSession(SessionPayload payload) {
                 addSpringRuntimeVersion(payload.getDevice());
             }
         };

--- a/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
@@ -19,7 +19,7 @@ public class SpringBootConfiguration {
     Callback springBootVersionErrorCallback() {
         Callback callback = new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 addSpringRuntimeVersion(report.getDevice());
             }
         };

--- a/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
@@ -31,8 +31,9 @@ public class SpringBootConfiguration {
     OnSession springBootVersionSessionCallback() {
         OnSession onSession = new OnSession() {
             @Override
-            public void onSession(SessionPayload payload) {
+            public Boolean onSession(SessionPayload payload) {
                 addSpringRuntimeVersion(payload.getDevice());
+                return true;
             }
         };
         bugsnag.addOnSession(onSession);

--- a/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
@@ -190,7 +190,7 @@ public class SpringMvcTest {
         Report report;
         Callback callback = new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.setSeverity(Severity.WARNING);
             }
         };

--- a/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
@@ -190,8 +190,9 @@ public class SpringMvcTest {
         Report report;
         Callback callback = new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.setSeverity(Severity.WARNING);
+                return true;
             }
         };
 

--- a/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
@@ -190,7 +190,7 @@ public class SpringMvcTest {
         Report report;
         Callback callback = new Callback() {
             @Override
-            public Boolean onError(Report report) {
+            public boolean onError(Report report) {
                 report.setSeverity(Severity.WARNING);
                 return true;
             }

--- a/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestController.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestController.java
@@ -67,8 +67,9 @@ public class TestController {
         } catch (TypeMismatchException ex) {
             bugsnag.notify(ex, new Callback() {
                 @Override
-                public void onError(Report report) {
+                public Boolean onError(Report report) {
                     report.setSeverity(Severity.WARNING);
+                    return true;
                 }
             });
         }

--- a/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestController.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestController.java
@@ -67,7 +67,7 @@ public class TestController {
         } catch (TypeMismatchException ex) {
             bugsnag.notify(ex, new Callback() {
                 @Override
-                public void beforeNotify(Report report) {
+                public void onError(Report report) {
                     report.setSeverity(Severity.WARNING);
                 }
             });

--- a/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestController.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestController.java
@@ -67,7 +67,7 @@ public class TestController {
         } catch (TypeMismatchException ex) {
             bugsnag.notify(ex, new Callback() {
                 @Override
-                public Boolean onError(Report report) {
+                public boolean onError(Report report) {
                     report.setSeverity(Severity.WARNING);
                     return true;
                 }

--- a/bugsnag/src/main/java/com/bugsnag/BeforeSendSession.java
+++ b/bugsnag/src/main/java/com/bugsnag/BeforeSendSession.java
@@ -1,5 +1,5 @@
 package com.bugsnag;
 
 interface BeforeSendSession {
-    void beforeSendSession(SessionPayload payload);
+    void onSession(SessionPayload payload);
 }

--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -676,7 +676,7 @@ public class Bugsnag implements Closeable {
         return Collections.emptySet();
     }
 
-    void addBeforeSendSession(BeforeSendSession beforeSendSession) {
-        sessionTracker.addBeforeSendSession(beforeSendSession);
+    void addOnSession(OnSession onSession) {
+        sessionTracker.addOnSession(onSession);
     }
 }

--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -455,8 +455,8 @@ public class Bugsnag implements Closeable {
         // Run all client-wide onError callbacks
         for (Callback callback : config.callbacks) {
             try {
-                Boolean proceed = callback.onError(report);
-                if (Boolean.FALSE.equals(proceed) || report.getShouldCancel()) {
+                boolean proceed = callback.onError(report);
+                if (!proceed || report.getShouldCancel()) {
                     LOGGER.debug("Error not reported to Bugsnag - cancelled by a client-wide onError callback");
                     return false;
                 }
@@ -471,8 +471,8 @@ public class Bugsnag implements Closeable {
         // Run the report-specific onError callback, if given
         if (reportCallback != null) {
             try {
-                Boolean proceed = reportCallback.onError(report);
-                if (Boolean.FALSE.equals(proceed) || report.getShouldCancel()) {
+                boolean proceed = reportCallback.onError(report);
+                if (!proceed || report.getShouldCancel()) {
                     LOGGER.debug("Error not reported to Bugsnag - cancelled by a report-specific callback");
                     return false;
                 }

--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -455,13 +455,9 @@ public class Bugsnag implements Closeable {
         // Run all client-wide onError callbacks
         for (Callback callback : config.callbacks) {
             try {
-                // Run the callback
-                callback.onError(report);
-
-                // Check if callback cancelled delivery
-                if (report.getShouldCancel()) {
-                    LOGGER.debug("Error not reported to Bugsnag - "
-                            + "cancelled by a client-wide onError callback");
+                Boolean proceed = callback.onError(report);
+                if (Boolean.FALSE.equals(proceed) || report.getShouldCancel()) {
+                    LOGGER.debug("Error not reported to Bugsnag - cancelled by a client-wide onError callback");
                     return false;
                 }
             } catch (Throwable ex) {
@@ -475,13 +471,9 @@ public class Bugsnag implements Closeable {
         // Run the report-specific onError callback, if given
         if (reportCallback != null) {
             try {
-                // Run the callback
-                reportCallback.onError(report);
-
-                // Check if callback cancelled delivery
-                if (report.getShouldCancel()) {
-                    LOGGER.debug(
-                            "Error not reported to Bugsnag - cancelled by a report-specific callback");
+                Boolean proceed = reportCallback.onError(report);
+                if (Boolean.FALSE.equals(proceed) || report.getShouldCancel()) {
+                    LOGGER.debug("Error not reported to Bugsnag - cancelled by a report-specific callback");
                     return false;
                 }
             } catch (Throwable ex) {

--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -452,16 +452,16 @@ public class Bugsnag implements Closeable {
             return false;
         }
 
-        // Run all client-wide beforeNotify callbacks
+        // Run all client-wide onError callbacks
         for (Callback callback : config.callbacks) {
             try {
                 // Run the callback
-                callback.beforeNotify(report);
+                callback.onError(report);
 
                 // Check if callback cancelled delivery
                 if (report.getShouldCancel()) {
                     LOGGER.debug("Error not reported to Bugsnag - "
-                            + "cancelled by a client-wide beforeNotify callback");
+                            + "cancelled by a client-wide onError callback");
                     return false;
                 }
             } catch (Throwable ex) {
@@ -472,11 +472,11 @@ public class Bugsnag implements Closeable {
         // Add thread metadata to the report
         report.mergeMetadata(THREAD_METADATA.get());
 
-        // Run the report-specific beforeNotify callback, if given
+        // Run the report-specific onError callback, if given
         if (reportCallback != null) {
             try {
                 // Run the callback
-                reportCallback.beforeNotify(report);
+                reportCallback.onError(report);
 
                 // Check if callback cancelled delivery
                 if (report.getShouldCancel()) {

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
@@ -134,7 +134,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
                         calculateSeverity(event),
                         new Callback() {
                             @Override
-                            public void beforeNotify(Report report) {
+                            public void onError(Report report) {
 
                                 // Add some data from the logging event
                                 report.addToTab("Log event data",
@@ -146,7 +146,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
                                 populateContextData(report, event);
 
                                 if (reportCallback != null) {
-                                    reportCallback.beforeNotify(report);
+                                    reportCallback.onError(report);
                                 }
                             }
                         });
@@ -270,7 +270,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         // Add a callback to put global metadata on every report
         bugsnag.addCallback(new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
 
                 for (LogbackMetadata metadata : globalMetadata) {
                     for (LogbackMetadataTab tab : metadata.getTabs()) {

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
@@ -134,7 +134,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
                         calculateSeverity(event),
                         new Callback() {
                             @Override
-                            public Boolean onError(Report report) {
+                            public boolean onError(Report report) {
 
                                 // Add some data from the logging event
                                 report.addToTab("Log event data",
@@ -146,8 +146,8 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
                                 populateContextData(report, event);
 
                                 if (reportCallback != null) {
-                                    Boolean proceed = reportCallback.onError(report);
-                                    if (Boolean.FALSE.equals(proceed)) {
+                                    boolean proceed = reportCallback.onError(report);
+                                    if (!proceed) {
                                         return false; // suppress delivery
                                     }
                                 }
@@ -274,7 +274,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         // Add a callback to put global metadata on every report
         bugsnag.addCallback(new Callback() {
             @Override
-            public Boolean onError(Report report) {
+            public boolean onError(Report report) {
 
                 for (LogbackMetadata metadata : globalMetadata) {
                     for (LogbackMetadataTab tab : metadata.getTabs()) {

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
@@ -134,7 +134,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
                         calculateSeverity(event),
                         new Callback() {
                             @Override
-                            public void onError(Report report) {
+                            public Boolean onError(Report report) {
 
                                 // Add some data from the logging event
                                 report.addToTab("Log event data",
@@ -146,8 +146,12 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
                                 populateContextData(report, event);
 
                                 if (reportCallback != null) {
-                                    reportCallback.onError(report);
+                                    Boolean proceed = reportCallback.onError(report);
+                                    if (Boolean.FALSE.equals(proceed)) {
+                                        return false; // suppress delivery
+                                    }
                                 }
+                                return true;
                             }
                         });
             }
@@ -270,7 +274,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         // Add a callback to put global metadata on every report
         bugsnag.addCallback(new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
 
                 for (LogbackMetadata metadata : globalMetadata) {
                     for (LogbackMetadataTab tab : metadata.getTabs()) {
@@ -282,6 +286,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
                     }
 
                 }
+                return true;
             }
         });
 

--- a/bugsnag/src/main/java/com/bugsnag/OnSession.java
+++ b/bugsnag/src/main/java/com/bugsnag/OnSession.java
@@ -2,5 +2,5 @@ package com.bugsnag;
 
 @FunctionalInterface
 interface OnSession {
-    Boolean onSession(SessionPayload payload);
+    boolean onSession(SessionPayload payload);
 }

--- a/bugsnag/src/main/java/com/bugsnag/OnSession.java
+++ b/bugsnag/src/main/java/com/bugsnag/OnSession.java
@@ -1,5 +1,5 @@
 package com.bugsnag;
 
-interface BeforeSendSession {
+interface OnSession {
     void onSession(SessionPayload payload);
 }

--- a/bugsnag/src/main/java/com/bugsnag/OnSession.java
+++ b/bugsnag/src/main/java/com/bugsnag/OnSession.java
@@ -1,5 +1,6 @@
 package com.bugsnag;
 
+@FunctionalInterface
 interface OnSession {
-    void onSession(SessionPayload payload);
+    Boolean onSession(SessionPayload payload);
 }

--- a/bugsnag/src/main/java/com/bugsnag/SessionPayload.java
+++ b/bugsnag/src/main/java/com/bugsnag/SessionPayload.java
@@ -9,10 +9,21 @@ final class SessionPayload {
 
     private final Collection<SessionCount> sessionCounts;
     private final Diagnostics diagnostics;
+    private final Map<String, Object> device;
+    private final Map<String, Object> app;
 
     SessionPayload(Collection<SessionCount> sessionCounts, Configuration configuration) {
         this.sessionCounts = sessionCounts;
         diagnostics = new Diagnostics(configuration);
+        this.device = null;
+        this.app = null;
+    }
+
+    SessionPayload(Collection<SessionCount> sessionCounts, Map<String, Object> device, Map<String, Object> app) {
+        this.sessionCounts = sessionCounts;
+        this.diagnostics = null;
+        this.device = device;
+        this.app = app;
     }
 
     @Expose
@@ -22,12 +33,12 @@ final class SessionPayload {
 
     @Expose
     Map<String, Object> getDevice() {
-        return diagnostics.device;
+        return device != null ? device : diagnostics.device;
     }
 
     @Expose
     Map<String, Object> getApp() {
-        return diagnostics.app;
+        return app != null ? app : diagnostics.app;
     }
 
     @Expose

--- a/bugsnag/src/main/java/com/bugsnag/SessionTracker.java
+++ b/bugsnag/src/main/java/com/bugsnag/SessionTracker.java
@@ -16,8 +16,7 @@ class SessionTracker {
     private final Configuration config;
     private final ThreadLocal<Session> session = new ThreadLocal<Session>();
     private final AtomicReference<SessionCount> batchCount = new AtomicReference<SessionCount>();
-    private final Collection<SessionCount>
-            enqueuedSessionCounts = new ConcurrentLinkedQueue<SessionCount>();
+    private final Collection<SessionCount> enqueuedSessionCounts = new ConcurrentLinkedQueue<SessionCount>();
 
     private final Semaphore flushingRequest = new Semaphore(1);
     private final AtomicBoolean shuttingDown = new AtomicBoolean();
@@ -86,12 +85,11 @@ class SessionTracker {
 
         if (!enqueuedSessionCounts.isEmpty() && flushingRequest.tryAcquire(1)) {
             try {
-                Collection<SessionCount> requestValues
-                        = new ArrayList<SessionCount>(enqueuedSessionCounts);
+                Collection<SessionCount> requestValues = new ArrayList<SessionCount>(enqueuedSessionCounts);
                 SessionPayload payload = new SessionPayload(requestValues, config);
 
                 for (BeforeSendSession callback : sessionCallbacks) {
-                    callback.beforeSendSession(payload);
+                    callback.onSession(payload);
                 }
 
                 Delivery delivery = config.sessionDelivery;

--- a/bugsnag/src/main/java/com/bugsnag/SessionTracker.java
+++ b/bugsnag/src/main/java/com/bugsnag/SessionTracker.java
@@ -86,14 +86,12 @@ class SessionTracker {
 
         if (!enqueuedSessionCounts.isEmpty() && flushingRequest.tryAcquire(1)) {
             try {
-                Collection<SessionCount> requestValues =
-                        new ArrayList<SessionCount>(enqueuedSessionCounts);
+                Collection<SessionCount> requestValues = new ArrayList<SessionCount>(enqueuedSessionCounts);
 
                 Collection<SessionCount> approvedSessions = new ArrayList<SessionCount>();
 
                 for (SessionCount sessionCount : requestValues) {
-                    SessionPayload singlePayload =
-                            new SessionPayload(Collections.singleton(sessionCount), config);
+                    SessionPayload singlePayload = new SessionPayload(Collections.singleton(sessionCount), config);
 
                     boolean sendThisSession = true;
                     for (OnSession callback : sessionCallbacks) {

--- a/bugsnag/src/main/java/com/bugsnag/SessionTracker.java
+++ b/bugsnag/src/main/java/com/bugsnag/SessionTracker.java
@@ -3,8 +3,8 @@ package com.bugsnag;
 import com.bugsnag.delivery.Delivery;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;

--- a/bugsnag/src/main/java/com/bugsnag/SessionTracker.java
+++ b/bugsnag/src/main/java/com/bugsnag/SessionTracker.java
@@ -20,7 +20,7 @@ class SessionTracker {
 
     private final Semaphore flushingRequest = new Semaphore(1);
     private final AtomicBoolean shuttingDown = new AtomicBoolean();
-    private final Collection<BeforeSendSession> sessionCallbacks = new ConcurrentLinkedQueue<BeforeSendSession>();
+    private final Collection<OnSession> sessionCallbacks = new ConcurrentLinkedQueue<OnSession>();
 
     SessionTracker(Configuration configuration) {
         this.config = configuration;
@@ -88,7 +88,7 @@ class SessionTracker {
                 Collection<SessionCount> requestValues = new ArrayList<SessionCount>(enqueuedSessionCounts);
                 SessionPayload payload = new SessionPayload(requestValues, config);
 
-                for (BeforeSendSession callback : sessionCallbacks) {
+                for (OnSession callback : sessionCallbacks) {
                     callback.onSession(payload);
                 }
 
@@ -107,7 +107,7 @@ class SessionTracker {
         }
     }
 
-    void addBeforeSendSession(BeforeSendSession beforeSendSession) {
-        sessionCallbacks.add(beforeSendSession);
+    void addOnSession(OnSession onSession) {
+        sessionCallbacks.add(onSession);
     }
 }

--- a/bugsnag/src/main/java/com/bugsnag/SessionTracker.java
+++ b/bugsnag/src/main/java/com/bugsnag/SessionTracker.java
@@ -87,15 +87,15 @@ class SessionTracker {
         if (!enqueuedSessionCounts.isEmpty() && flushingRequest.tryAcquire(1)) {
             try {
                 Collection<SessionCount> requestValues = new ArrayList<SessionCount>(enqueuedSessionCounts);
-
                 Collection<SessionCount> approvedSessions = new ArrayList<SessionCount>();
+                SessionPayload firstPayload = null;
 
                 for (SessionCount sessionCount : requestValues) {
-                    SessionPayload singlePayload = new SessionPayload(Collections.singleton(sessionCount), config);
+                    SessionPayload payload = new SessionPayload(Collections.singleton(sessionCount), config);
 
                     boolean sendThisSession = true;
                     for (OnSession callback : sessionCallbacks) {
-                        if (!callback.onSession(singlePayload)) {
+                        if (!callback.onSession(payload)) {
                             sendThisSession = false;
                             break;
                         }
@@ -103,13 +103,19 @@ class SessionTracker {
 
                     if (sendThisSession) {
                         approvedSessions.add(sessionCount);
+                        if (firstPayload == null) {
+                            firstPayload = payload;
+                        }
                     }
                 }
 
                 if (!approvedSessions.isEmpty()) {
-                    SessionPayload payload = new SessionPayload(approvedSessions, config);
+                    // Reuse the device/app from the first approved payload to preserve runtime
+                    // versions
+                    SessionPayload batchPayload = new SessionPayload(approvedSessions, firstPayload.getDevice(),
+                            firstPayload.getApp());
                     Delivery delivery = config.sessionDelivery;
-                    delivery.deliver(config.serializer, payload, config.getSessionApiHeaders());
+                    delivery.deliver(config.serializer, batchPayload, config.getSessionApiHeaders());
                 }
 
                 enqueuedSessionCounts.removeAll(requestValues);

--- a/bugsnag/src/main/java/com/bugsnag/SessionTracker.java
+++ b/bugsnag/src/main/java/com/bugsnag/SessionTracker.java
@@ -85,16 +85,36 @@ class SessionTracker {
 
         if (!enqueuedSessionCounts.isEmpty() && flushingRequest.tryAcquire(1)) {
             try {
-                Collection<SessionCount> requestValues = new ArrayList<SessionCount>(enqueuedSessionCounts);
-                SessionPayload payload = new SessionPayload(requestValues, config);
+                Collection<SessionCount> requestValues =
+                        new ArrayList<SessionCount>(enqueuedSessionCounts);
 
-                for (OnSession callback : sessionCallbacks) {
-                    callback.onSession(payload);
+                Collection<SessionCount> approvedSessions = new ArrayList<SessionCount>();
+
+                for (SessionCount sessionCount : requestValues) {
+                    SessionPayload singlePayload =
+                            new SessionPayload(Collections.singleton(sessionCount), config);
+
+                    boolean sendThisSession = true;
+                    for (OnSession callback : sessionCallbacks) {
+                        if (!callback.onSession(singlePayload)) {
+                            sendThisSession = false;
+                            break;
+                        }
+                    }
+
+                    if (sendThisSession) {
+                        approvedSessions.add(sessionCount);
+                    }
                 }
 
-                Delivery delivery = config.sessionDelivery;
-                delivery.deliver(config.serializer, payload, config.getSessionApiHeaders());
+                if (!approvedSessions.isEmpty()) {
+                    SessionPayload payload = new SessionPayload(approvedSessions, config);
+                    Delivery delivery = config.sessionDelivery;
+                    delivery.deliver(config.serializer, payload, config.getSessionApiHeaders());
+                }
+
                 enqueuedSessionCounts.removeAll(requestValues);
+
             } finally {
                 flushingRequest.release(1);
             }

--- a/bugsnag/src/main/java/com/bugsnag/SessionTracker.java
+++ b/bugsnag/src/main/java/com/bugsnag/SessionTracker.java
@@ -3,6 +3,7 @@ package com.bugsnag;
 import com.bugsnag.delivery.Delivery;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Collection;
 import java.util.Date;
 import java.util.UUID;

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/AppCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/AppCallback.java
@@ -11,7 +11,7 @@ public class AppCallback implements Callback {
     }
 
     @Override
-    public void beforeNotify(Report report) {
+    public void onError(Report report) {
         if (config.appType != null) {
             report.setAppInfo("type", config.appType);
         }

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/AppCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/AppCallback.java
@@ -11,7 +11,7 @@ public class AppCallback implements Callback {
     }
 
     @Override
-    public void onError(Report report) {
+    public Boolean onError(Report report) {
         if (config.appType != null) {
             report.setAppInfo("type", config.appType);
         }
@@ -23,5 +23,6 @@ public class AppCallback implements Callback {
         if (config.releaseStage != null) {
             report.setAppInfo("releaseStage", config.releaseStage);
         }
+        return true;
     }
 }

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/AppCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/AppCallback.java
@@ -11,7 +11,7 @@ public class AppCallback implements Callback {
     }
 
     @Override
-    public Boolean onError(Report report) {
+    public boolean onError(Report report) {
         if (config.appType != null) {
             report.setAppInfo("type", config.appType);
         }

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/Callback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/Callback.java
@@ -8,5 +8,5 @@ public interface Callback {
      *
      * @param report the report to perform changes on.
      */
-    void beforeNotify(Report report);
+    void onError(Report report);
 }

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/Callback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/Callback.java
@@ -12,5 +12,5 @@ public interface Callback {
      * @param report the report to perform changes on.
      * @return true to send, false to suppress delivery
      */
-    Boolean onError(Report report);
+    boolean onError(Report report);
 }

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/Callback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/Callback.java
@@ -5,8 +5,12 @@ import com.bugsnag.Report;
 public interface Callback {
     /**
      * Perform changes to the report before delivery.
+     * Return {@code true} to continue sending, or {@code false} to cancel delivery.
+     * Implementations may also call {@code report.cancel()} for backward
+     * compatibility.
      *
      * @param report the report to perform changes on.
+     * @return true to send, false to suppress delivery
      */
-    void onError(Report report);
+    Boolean onError(Report report);
 }

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
@@ -84,7 +84,7 @@ public class DeviceCallback implements Callback {
     }
 
     @Override
-    public Boolean onError(Report report) {
+    public boolean onError(Report report) {
         report
                 .addToTab("device", "osArch", System.getProperty("os.arch"))
                 .addToTab("device", "locale", Locale.getDefault())

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
@@ -84,12 +84,13 @@ public class DeviceCallback implements Callback {
     }
 
     @Override
-    public void onError(Report report) {
+    public Boolean onError(Report report) {
         report
                 .addToTab("device", "osArch", System.getProperty("os.arch"))
                 .addToTab("device", "locale", Locale.getDefault())
                 .setDeviceInfo("hostname", getHostnameValue())
                 .setDeviceInfo("osName", System.getProperty("os.name"))
                 .setDeviceInfo("osVersion", System.getProperty("os.version"));
+        return true;
     }
 }

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
@@ -84,7 +84,7 @@ public class DeviceCallback implements Callback {
     }
 
     @Override
-    public void beforeNotify(Report report) {
+    public void onError(Report report) {
         report
                 .addToTab("device", "osArch", System.getProperty("os.arch"))
                 .addToTab("device", "locale", Locale.getDefault())

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/JakartaServletCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/JakartaServletCallback.java
@@ -26,7 +26,7 @@ public class JakartaServletCallback implements Callback {
     }
 
     @Override
-    public Boolean onError(Report report) {
+    public boolean onError(Report report) {
         // Check if we have any servlet request data available
         HttpServletRequest request = BugsnagServletRequestListener.getServletRequest();
         if (request == null) {

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/JakartaServletCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/JakartaServletCallback.java
@@ -26,7 +26,7 @@ public class JakartaServletCallback implements Callback {
     }
 
     @Override
-    public void beforeNotify(Report report) {
+    public void onError(Report report) {
         // Check if we have any servlet request data available
         HttpServletRequest request = BugsnagServletRequestListener.getServletRequest();
         if (request == null) {

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/JakartaServletCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/JakartaServletCallback.java
@@ -26,11 +26,11 @@ public class JakartaServletCallback implements Callback {
     }
 
     @Override
-    public void onError(Report report) {
+    public Boolean onError(Report report) {
         // Check if we have any servlet request data available
         HttpServletRequest request = BugsnagServletRequestListener.getServletRequest();
         if (request == null) {
-            return;
+            return true; // nothing to add, but do not cancel
         }
 
         // Add request information to metadata
@@ -46,6 +46,7 @@ public class JakartaServletCallback implements Callback {
         if (report.getContext() == null) {
             report.setContext(request.getMethod() + " " + request.getRequestURI());
         }
+        return true;
     }
 
     private String getClientIp(HttpServletRequest request) {

--- a/bugsnag/src/test/java/com/bugsnag/AppenderMetadataTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderMetadataTest.java
@@ -111,11 +111,11 @@ public class AppenderMetadataTest {
         // Send three test logs, the first one with report metadata added
         LOGGER.warn(new BugsnagMarker(new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.addToTab("report", "some key", "some report value");
+                return true;
             }
         }), "Test exception", new RuntimeException("test"));
-
 
         LOGGER.warn("Test exception", new RuntimeException("test"));
         Bugsnag.clearThreadMetadata();

--- a/bugsnag/src/test/java/com/bugsnag/AppenderMetadataTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderMetadataTest.java
@@ -111,7 +111,7 @@ public class AppenderMetadataTest {
         // Send three test logs, the first one with report metadata added
         LOGGER.warn(new BugsnagMarker(new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.addToTab("report", "some key", "some report value");
             }
         }), "Test exception", new RuntimeException("test"));

--- a/bugsnag/src/test/java/com/bugsnag/AppenderMetadataTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderMetadataTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import com.bugsnag.callbacks.Callback;
 import com.bugsnag.delivery.Delivery;
 import com.bugsnag.logback.BugsnagMarker;
 
@@ -109,12 +108,9 @@ public class AppenderMetadataTest {
         Bugsnag.addThreadMetadata("thread", "some key", "some thread value");
 
         // Send three test logs, the first one with report metadata added
-        LOGGER.warn(new BugsnagMarker(new Callback() {
-            @Override
-            public Boolean onError(Report report) {
-                report.addToTab("report", "some key", "some report value");
-                return true;
-            }
+        LOGGER.warn(new BugsnagMarker(report -> {
+            report.addToTab("report", "some key", "some report value");
+            return true;
         }), "Test exception", new RuntimeException("test"));
 
         LOGGER.warn("Test exception", new RuntimeException("test"));

--- a/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.bugsnag.callbacks.Callback;
 import com.bugsnag.delivery.Delivery;
 import com.bugsnag.logback.ProxyConfiguration;
 
@@ -296,19 +295,16 @@ public class AppenderTest {
     public void testCallback() {
 
         // Setup a callback to set the user
-        appender.addCallback(new Callback() {
-            @Override
-            public Boolean onError(Report report) {
-                report.setUserName("User Name");
-                report.setUserEmail("user@example.com");
-                report.setUserId("12345");
+        appender.addCallback(report -> {
+            report.setUserName("User Name");
+            report.setUserEmail("user@example.com");
+            report.setUserId("12345");
 
-                report.setContext("the context");
+            report.setContext("the context");
 
-                report.setGroupingHash("the grouping hash");
-                report.setApiKey("newapikey");
-                return true;
-            }
+            report.setGroupingHash("the grouping hash");
+            report.setApiKey("newapikey");
+            return true;
         });
 
         // Send a log message

--- a/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
@@ -298,7 +298,7 @@ public class AppenderTest {
         // Setup a callback to set the user
         appender.addCallback(new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.setUserName("User Name");
                 report.setUserEmail("user@example.com");
                 report.setUserId("12345");
@@ -306,8 +306,8 @@ public class AppenderTest {
                 report.setContext("the context");
 
                 report.setGroupingHash("the grouping hash");
-
                 report.setApiKey("newapikey");
+                return true;
             }
         });
 

--- a/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
@@ -298,7 +298,7 @@ public class AppenderTest {
         // Setup a callback to set the user
         appender.addCallback(new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.setUserName("User Name");
                 report.setUserEmail("user@example.com");
                 report.setUserId("12345");

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import com.bugsnag.callbacks.Callback;
 import com.bugsnag.delivery.Delivery;
 import com.bugsnag.delivery.HttpDelivery;
 import com.bugsnag.delivery.OutputStreamDelivery;
@@ -186,15 +185,12 @@ public class BugsnagTest {
             public void close() {
             }
         });
-        assertTrue(bugsnag.notify(new Throwable(), new Callback() {
-            @Override
-            public Boolean onError(Report report) {
-                report.addToTab("firsttab", "testredact1", "secretpassword");
-                report.addToTab("firsttab", "testredact2", "secretpassword");
-                report.addToTab("firsttab", "testredact3", "secretpassword");
-                report.addToTab("secondtab", "testredact1", "secretpassword");
-                return true;
-            }
+        assertTrue(bugsnag.notify(new Throwable(), report -> {
+            report.addToTab("firsttab", "testredact1", "secretpassword");
+            report.addToTab("firsttab", "testredact2", "secretpassword");
+            report.addToTab("firsttab", "testredact3", "secretpassword");
+            report.addToTab("secondtab", "testredact1", "secretpassword");
+            return true;
         }));
     }
 
@@ -222,18 +218,15 @@ public class BugsnagTest {
             }
         });
 
-        assertTrue(bugsnag.notify(new Throwable(), new Callback() {
-            @Override
-            public Boolean onError(Report report) {
-                Map<String, String> headers = new HashMap<String, String>();
-                headers.put("Authorization", "User:Password");
-                headers.put("authorization", "User:Password");
-                headers.put("Cookie", "123456ABCDEF");
-                headers.put("cookie", "123456ABCDEF");
+        assertTrue(bugsnag.notify(new Throwable(), report -> {
+            Map<String, String> headers = new HashMap<String, String>();
+            headers.put("Authorization", "User:Password");
+            headers.put("authorization", "User:Password");
+            headers.put("Cookie", "123456ABCDEF");
+            headers.put("cookie", "123456ABCDEF");
 
-                report.addToTab("request", "headers", headers);
-                return true;
-            }
+            report.addToTab("request", "headers", headers);
+            return true;
         }));
     }
 
@@ -252,23 +245,17 @@ public class BugsnagTest {
             public void close() {
             }
         });
-        assertTrue(bugsnag.notify(new Throwable(), new Callback() {
-            @Override
-            public Boolean onError(Report report) {
-                report.setUser("123", "test@example.com", "test name");
-                return true;
-            }
+        assertTrue(bugsnag.notify(new Throwable(), report -> {
+            report.setUser("123", "test@example.com", "test name");
+            return true;
         }));
     }
 
     @Test
     public void testContext() {
-        bugsnag.addCallback(new Callback() {
-            @Override
-            public Boolean onError(Report report) {
-                report.setContext("the context");
-                return true;
-            }
+        bugsnag.addCallback(report -> {
+            report.setContext("the context");
+            return true;
         });
         bugsnag.setDelivery(new Delivery() {
             @Override
@@ -286,12 +273,9 @@ public class BugsnagTest {
 
     @Test
     public void testGroupingHash() {
-        bugsnag.addCallback(new Callback() {
-            @Override
-            public Boolean onError(Report report) {
-                report.setGroupingHash("the grouping hash");
-                return true;
-            }
+        bugsnag.addCallback(report -> {
+            report.setGroupingHash("the grouping hash");
+            return true;
         });
         bugsnag.setDelivery(new Delivery() {
             @Override
@@ -309,12 +293,9 @@ public class BugsnagTest {
 
     @Test
     public void testSingleCallback() {
-        bugsnag.addCallback(new Callback() {
-            @Override
-            public Boolean onError(Report report) {
-                report.setApiKey("newapikey");
-                return true;
-            }
+        bugsnag.addCallback(report -> {
+            report.setApiKey("newapikey");
+            return true;
         });
         bugsnag.setDelivery(new Delivery() {
             @Override
@@ -344,30 +325,21 @@ public class BugsnagTest {
             }
         });
 
-        assertTrue(bugsnag.notify(new Throwable(), new Callback() {
-            @Override
-            public Boolean onError(Report report) {
-                report.setApiKey("newapikey");
-                return true;
-            }
+        assertTrue(bugsnag.notify(new Throwable(), report -> {
+            report.setApiKey("newapikey");
+            return true;
         }));
     }
 
     @Test
     public void testCallbackOrder() {
-        bugsnag.addCallback(new Callback() {
-            @Override
-            public Boolean onError(Report report) {
-                report.setApiKey("newapikey");
-                return true;
-            }
+        bugsnag.addCallback(report -> {
+            report.setApiKey("newapikey");
+            return true;
         });
-        bugsnag.addCallback(new Callback() {
-            @Override
-            public Boolean onError(Report report) {
-                report.setApiKey("secondnewapikey");
-                return true;
-            }
+        bugsnag.addCallback(report -> {
+            report.setApiKey("secondnewapikey");
+            return true;
         });
         bugsnag.setDelivery(new Delivery() {
             @Override
@@ -386,12 +358,9 @@ public class BugsnagTest {
     @Test
     public void testCallbackCancel() {
         bugsnag.setDelivery(BugsnagTestUtils.generateDelivery());
-        bugsnag.addCallback(new Callback() {
-            @Override
-            public Boolean onError(Report report) {
-                report.cancel();
-                return true; // cancellation flag respected
-            }
+        bugsnag.addCallback(report -> {
+            report.cancel();
+            return true; // cancellation flag respected
         });
         // Test the report is not sent
         assertFalse(bugsnag.notify(new Throwable()));

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
@@ -188,7 +188,7 @@ public class BugsnagTest {
         });
         assertTrue(bugsnag.notify(new Throwable(), new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.addToTab("firsttab", "testredact1", "secretpassword");
                 report.addToTab("firsttab", "testredact2", "secretpassword");
                 report.addToTab("firsttab", "testredact3", "secretpassword");
@@ -223,7 +223,7 @@ public class BugsnagTest {
 
         assertTrue(bugsnag.notify(new Throwable(), new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 Map<String, String> headers = new HashMap<String, String>();
                 headers.put("Authorization", "User:Password");
                 headers.put("authorization", "User:Password");
@@ -252,7 +252,7 @@ public class BugsnagTest {
         });
         assertTrue(bugsnag.notify(new Throwable(), new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.setUser("123", "test@example.com", "test name");
             }
         }));
@@ -262,7 +262,7 @@ public class BugsnagTest {
     public void testContext() {
         bugsnag.addCallback(new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.setContext("the context");
             }
         });
@@ -284,7 +284,7 @@ public class BugsnagTest {
     public void testGroupingHash() {
         bugsnag.addCallback(new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.setGroupingHash("the grouping hash");
             }
         });
@@ -306,7 +306,7 @@ public class BugsnagTest {
     public void testSingleCallback() {
         bugsnag.addCallback(new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.setApiKey("newapikey");
             }
         });
@@ -340,7 +340,7 @@ public class BugsnagTest {
 
         assertTrue(bugsnag.notify(new Throwable(), new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.setApiKey("newapikey");
             }
         }));
@@ -350,13 +350,13 @@ public class BugsnagTest {
     public void testCallbackOrder() {
         bugsnag.addCallback(new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.setApiKey("newapikey");
             }
         });
         bugsnag.addCallback(new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.setApiKey("secondnewapikey");
             }
         });
@@ -379,7 +379,7 @@ public class BugsnagTest {
         bugsnag.setDelivery(BugsnagTestUtils.generateDelivery());
         bugsnag.addCallback(new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.cancel();
             }
         });

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
@@ -188,11 +188,12 @@ public class BugsnagTest {
         });
         assertTrue(bugsnag.notify(new Throwable(), new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.addToTab("firsttab", "testredact1", "secretpassword");
                 report.addToTab("firsttab", "testredact2", "secretpassword");
                 report.addToTab("firsttab", "testredact3", "secretpassword");
                 report.addToTab("secondtab", "testredact1", "secretpassword");
+                return true;
             }
         }));
     }
@@ -223,7 +224,7 @@ public class BugsnagTest {
 
         assertTrue(bugsnag.notify(new Throwable(), new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 Map<String, String> headers = new HashMap<String, String>();
                 headers.put("Authorization", "User:Password");
                 headers.put("authorization", "User:Password");
@@ -231,6 +232,7 @@ public class BugsnagTest {
                 headers.put("cookie", "123456ABCDEF");
 
                 report.addToTab("request", "headers", headers);
+                return true;
             }
         }));
     }
@@ -252,8 +254,9 @@ public class BugsnagTest {
         });
         assertTrue(bugsnag.notify(new Throwable(), new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.setUser("123", "test@example.com", "test name");
+                return true;
             }
         }));
     }
@@ -262,8 +265,9 @@ public class BugsnagTest {
     public void testContext() {
         bugsnag.addCallback(new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.setContext("the context");
+                return true;
             }
         });
         bugsnag.setDelivery(new Delivery() {
@@ -284,8 +288,9 @@ public class BugsnagTest {
     public void testGroupingHash() {
         bugsnag.addCallback(new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.setGroupingHash("the grouping hash");
+                return true;
             }
         });
         bugsnag.setDelivery(new Delivery() {
@@ -306,8 +311,9 @@ public class BugsnagTest {
     public void testSingleCallback() {
         bugsnag.addCallback(new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.setApiKey("newapikey");
+                return true;
             }
         });
         bugsnag.setDelivery(new Delivery() {
@@ -340,8 +346,9 @@ public class BugsnagTest {
 
         assertTrue(bugsnag.notify(new Throwable(), new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.setApiKey("newapikey");
+                return true;
             }
         }));
     }
@@ -350,14 +357,16 @@ public class BugsnagTest {
     public void testCallbackOrder() {
         bugsnag.addCallback(new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.setApiKey("newapikey");
+                return true;
             }
         });
         bugsnag.addCallback(new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.setApiKey("secondnewapikey");
+                return true;
             }
         });
         bugsnag.setDelivery(new Delivery() {
@@ -379,8 +388,9 @@ public class BugsnagTest {
         bugsnag.setDelivery(BugsnagTestUtils.generateDelivery());
         bugsnag.addCallback(new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.cancel();
+                return true; // cancellation flag respected
             }
         });
         // Test the report is not sent

--- a/bugsnag/src/test/java/com/bugsnag/CallbackSuppressionTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/CallbackSuppressionTest.java
@@ -4,8 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.bugsnag.callbacks.Callback;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,12 +30,7 @@ public class CallbackSuppressionTest {
 
     @Test
     public void callbackReturningFalseSuppressesDelivery() {
-        bugsnag.addCallback(new Callback() {
-            @Override
-            public Boolean onError(Report report) {
-                return false; // explicit suppression
-            }
-        });
+        bugsnag.addCallback(report -> false); // explicit suppression
 
         boolean result = bugsnag.notify(new RuntimeException("Suppressed"));
         assertFalse("notify should return false when suppressed", result);
@@ -46,12 +39,7 @@ public class CallbackSuppressionTest {
 
     @Test
     public void callbackReturningTrueAllowsDelivery() {
-        bugsnag.addCallback(new Callback() {
-            @Override
-            public Boolean onError(Report report) {
-                return true; // allow
-            }
-        });
+        bugsnag.addCallback(report -> true); // allow
 
         boolean result = bugsnag.notify(new RuntimeException("Allowed"));
         assertTrue(result);

--- a/bugsnag/src/test/java/com/bugsnag/CallbackSuppressionTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/CallbackSuppressionTest.java
@@ -1,0 +1,57 @@
+package com.bugsnag;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.bugsnag.callbacks.Callback;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CallbackSuppressionTest {
+
+    private Bugsnag bugsnag;
+    private StubNotificationDelivery delivery;
+
+    @Before
+    public void setUp() {
+        bugsnag = new Bugsnag("apikey");
+        delivery = new StubNotificationDelivery();
+        bugsnag.setDelivery(delivery);
+    }
+
+    @After
+    public void tearDown() {
+        bugsnag.close();
+    }
+
+    @Test
+    public void callbackReturningFalseSuppressesDelivery() {
+        bugsnag.addCallback(new Callback() {
+            @Override
+            public Boolean onError(Report report) {
+                return false; // explicit suppression
+            }
+        });
+
+        boolean result = bugsnag.notify(new RuntimeException("Suppressed"));
+        assertFalse("notify should return false when suppressed", result);
+        assertEquals("No notifications should be delivered", 0, delivery.getNotifications().size());
+    }
+
+    @Test
+    public void callbackReturningTrueAllowsDelivery() {
+        bugsnag.addCallback(new Callback() {
+            @Override
+            public Boolean onError(Report report) {
+                return true; // allow
+            }
+        });
+
+        boolean result = bugsnag.notify(new RuntimeException("Allowed"));
+        assertTrue(result);
+        assertEquals(1, delivery.getNotifications().size());
+    }
+}

--- a/bugsnag/src/test/java/com/bugsnag/CallbackSuppressionTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/CallbackSuppressionTest.java
@@ -15,6 +15,9 @@ public class CallbackSuppressionTest {
     private Bugsnag bugsnag;
     private StubNotificationDelivery delivery;
 
+    /**
+     * Set up test fixtures.
+     */
     @Before
     public void setUp() {
         bugsnag = new Bugsnag("apikey");

--- a/bugsnag/src/test/java/com/bugsnag/ConcurrentCallbackTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/ConcurrentCallbackTest.java
@@ -30,14 +30,16 @@ public class ConcurrentCallbackTest {
 
         config.addCallback(new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 // modify the callback collection, when iterating to the next callback this
                 // should not crash
                 config.addCallback(new Callback() {
                     @Override
-                    public void onError(Report report) {
+                    public Boolean onError(Report report) {
+                        return true;
                     }
                 });
+                return true;
             }
         });
         bugsnag.notify(new RuntimeException());

--- a/bugsnag/src/test/java/com/bugsnag/ConcurrentCallbackTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/ConcurrentCallbackTest.java
@@ -30,11 +30,12 @@ public class ConcurrentCallbackTest {
 
         config.addCallback(new Callback() {
             @Override
-            public void beforeNotify(Report report) {
-                // modify the callback collection, when iterating to the next callback this should not crash
+            public void onError(Report report) {
+                // modify the callback collection, when iterating to the next callback this
+                // should not crash
                 config.addCallback(new Callback() {
                     @Override
-                    public void beforeNotify(Report report) {
+                    public void onError(Report report) {
                     }
                 });
             }

--- a/bugsnag/src/test/java/com/bugsnag/ConcurrentCallbackTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/ConcurrentCallbackTest.java
@@ -1,7 +1,5 @@
 package com.bugsnag;
 
-import com.bugsnag.callbacks.Callback;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,19 +26,11 @@ public class ConcurrentCallbackTest {
     public void testClientNotifyModification() {
         final Configuration config = bugsnag.getConfig();
 
-        config.addCallback(new Callback() {
-            @Override
-            public Boolean onError(Report report) {
-                // modify the callback collection, when iterating to the next callback this
-                // should not crash
-                config.addCallback(new Callback() {
-                    @Override
-                    public Boolean onError(Report report) {
-                        return true;
-                    }
-                });
-                return true;
-            }
+        config.addCallback(report -> {
+            // modify the callback collection, when iterating to the next callback this
+            // should not crash
+            config.addCallback(r -> true);
+            return true;
         });
         bugsnag.notify(new RuntimeException());
     }

--- a/bugsnag/src/test/java/com/bugsnag/ExceptionTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/ExceptionTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.bugsnag.callbacks.Callback;
 import com.bugsnag.delivery.Delivery;
 import com.bugsnag.serialization.Serializer;
 
@@ -60,29 +59,26 @@ public class ExceptionTest {
             public void close() {
             }
         });
-        assertTrue(bugsnag.notify(ogThrowable, new Callback() {
-            @Override
-            public Boolean onError(Report report) {
-                try {
-                    assertEquals(ogThrowable, report.getException());
-                    assertEquals("Test", report.getExceptionMessage());
-                    assertEquals("java.lang.RuntimeException", report.getExceptionName());
+        assertTrue(bugsnag.notify(ogThrowable, report -> {
+            try {
+                assertEquals(ogThrowable, report.getException());
+                assertEquals("Test", report.getExceptionMessage());
+                assertEquals("java.lang.RuntimeException", report.getExceptionName());
 
-                    report.setExceptionName("Foo");
-                    assertEquals("Foo", report.getExceptionName());
+                report.setExceptionName("Foo");
+                assertEquals("Foo", report.getExceptionName());
 
-                    List<Exception> exceptions = report.getExceptions();
-                    assertEquals(1, exceptions.size());
+                List<Exception> exceptions = report.getExceptions();
+                assertEquals(1, exceptions.size());
 
-                    Exception exception = exceptions.get(0);
-                    assertNotNull(exception);
-                    assertEquals("Foo", exception.getErrorClass());
-                    assertEquals("Test", exception.getMessage());
-                } catch (Throwable throwable) {
-                    report.cancel();
-                }
-                return !report.getShouldCancel();
+                Exception exception = exceptions.get(0);
+                assertNotNull(exception);
+                assertEquals("Foo", exception.getErrorClass());
+                assertEquals("Test", exception.getMessage());
+            } catch (Throwable throwable) {
+                report.cancel();
             }
+            return !report.getShouldCancel();
         }));
 
         bugsnag.close();

--- a/bugsnag/src/test/java/com/bugsnag/ExceptionTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/ExceptionTest.java
@@ -62,7 +62,7 @@ public class ExceptionTest {
         });
         assertTrue(bugsnag.notify(ogThrowable, new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 try {
                     assertEquals(ogThrowable, report.getException());
                     assertEquals("Test", report.getExceptionMessage());
@@ -70,7 +70,6 @@ public class ExceptionTest {
 
                     report.setExceptionName("Foo");
                     assertEquals("Foo", report.getExceptionName());
-
 
                     List<Exception> exceptions = report.getExceptions();
                     assertEquals(1, exceptions.size());
@@ -82,6 +81,7 @@ public class ExceptionTest {
                 } catch (Throwable throwable) {
                     report.cancel();
                 }
+                return !report.getShouldCancel();
             }
         }));
 

--- a/bugsnag/src/test/java/com/bugsnag/ExceptionTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/ExceptionTest.java
@@ -62,7 +62,7 @@ public class ExceptionTest {
         });
         assertTrue(bugsnag.notify(ogThrowable, new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 try {
                     assertEquals(ogThrowable, report.getException());
                     assertEquals("Test", report.getExceptionMessage());

--- a/bugsnag/src/test/java/com/bugsnag/JakartaServletCallbackTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/JakartaServletCallbackTest.java
@@ -83,7 +83,7 @@ public class JakartaServletCallbackTest {
     public void testRequestMetadataAdded() {
         Report report = generateReport(new java.lang.Exception("Spline reticulation failed"));
         JakartaServletCallback callback = new JakartaServletCallback();
-        callback.beforeNotify(report);
+        callback.onError(report);
 
         Map<String, Object> metadata = report.getMetadata();
         assertTrue(metadata.containsKey("request"));
@@ -120,7 +120,7 @@ public class JakartaServletCallbackTest {
     public void testRequestContextSet() {
         Report report = generateReport(new java.lang.Exception("Spline reticulation failed"));
         JakartaServletCallback callback = new JakartaServletCallback();
-        callback.beforeNotify(report);
+        callback.onError(report);
 
         assertEquals("PATCH /foo/bar", report.getContext());
     }
@@ -130,7 +130,7 @@ public class JakartaServletCallbackTest {
         Report report = generateReport(new java.lang.Exception("Spline reticulation failed"));
         report.setContext("Honey nut corn flakes");
         JakartaServletCallback callback = new JakartaServletCallback();
-        callback.beforeNotify(report);
+        callback.onError(report);
 
         assertEquals("Honey nut corn flakes", report.getContext());
     }

--- a/bugsnag/src/test/java/com/bugsnag/MarkerTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/MarkerTest.java
@@ -29,7 +29,7 @@ public class MarkerTest {
     public void createMarker() {
         callback = new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
 
             }
         };

--- a/bugsnag/src/test/java/com/bugsnag/MarkerTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/MarkerTest.java
@@ -26,12 +26,7 @@ public class MarkerTest {
      */
     @Before
     public void createMarker() {
-        callback = new Callback() {
-            @Override
-            public Boolean onError(Report report) {
-                return true;
-            }
-        };
+        callback = report -> true;
 
         marker = new BugsnagMarker(callback);
     }

--- a/bugsnag/src/test/java/com/bugsnag/MarkerTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/MarkerTest.java
@@ -13,7 +13,6 @@ import org.slf4j.Marker;
 
 import java.util.Iterator;
 
-
 /**
  * Tests for the Bugsnag Marker internal logic
  */
@@ -29,8 +28,8 @@ public class MarkerTest {
     public void createMarker() {
         callback = new Callback() {
             @Override
-            public void onError(Report report) {
-
+            public Boolean onError(Report report) {
+                return true;
             }
         };
 

--- a/bugsnag/src/test/java/com/bugsnag/SessionTrackerTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/SessionTrackerTest.java
@@ -10,14 +10,16 @@ import static org.junit.Assert.fail;
 
 import com.bugsnag.delivery.Delivery;
 import com.bugsnag.serialization.Serializer;
+
+import org.junit.Before;
+import org.junit.Test;
+
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.CountDownLatch;
-import org.junit.Before;
-import org.junit.Test;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class SessionTrackerTest {
 

--- a/bugsnag/src/test/java/com/bugsnag/SessionTrackerTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/SessionTrackerTest.java
@@ -10,17 +10,14 @@ import static org.junit.Assert.fail;
 
 import com.bugsnag.delivery.Delivery;
 import com.bugsnag.serialization.Serializer;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
-
+import java.util.concurrent.CountDownLatch;
+import org.junit.Before;
+import org.junit.Test;
 
 public class SessionTrackerTest {
 
@@ -185,7 +182,6 @@ public class SessionTrackerTest {
                 super.deliver(serializer, object, headers);
                 SessionPayload payload = (SessionPayload) object;
 
-
                 List<SessionCount> sessionCounts = (List<SessionCount>) payload.getSessionCounts();
                 assertEquals(3, sessionCounts.size());
 
@@ -284,7 +280,8 @@ public class SessionTrackerTest {
 
     @Test
     public void zeroSessionCount() {
-        CustomDelivery sessionDelivery = new CustomDelivery() {};
+        CustomDelivery sessionDelivery = new CustomDelivery() {
+        };
         configuration.sessionDelivery = sessionDelivery;
         sessionTracker.flushSessions(new Date(10120000L));
         sessionTracker.flushSessions(new Date(14000000L));
@@ -300,7 +297,8 @@ public class SessionTrackerTest {
 
     @Test
     public void testSessionShutdownDelivers() {
-        CustomDelivery delivery = new CustomDelivery() {};
+        CustomDelivery delivery = new CustomDelivery() {
+        };
         configuration.sessionDelivery = delivery;
 
         sessionTracker.startSession(new Date(), true);
@@ -311,7 +309,8 @@ public class SessionTrackerTest {
 
     @Test
     public void testMultiShutdown() {
-        CustomDelivery delivery = new CustomDelivery() {};
+        CustomDelivery delivery = new CustomDelivery() {
+        };
         configuration.sessionDelivery = delivery;
 
         sessionTracker.startSession(new Date(), true);

--- a/bugsnag/src/test/java/com/bugsnag/SessionTrackerTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/SessionTrackerTest.java
@@ -321,6 +321,35 @@ public class SessionTrackerTest {
         assertEquals(1, delivery.count.get());
     }
 
+    @Test
+    public void sessionDeliverySuppressedByCallback() {
+        // Set up a delivery stub which SHOULD NOT be invoked
+        CustomDelivery delivery = new CustomDelivery() {
+            @Override
+            public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
+                super.deliver(serializer, object, headers);
+                fail("Delivery should be suppressed by OnSession callback returning false");
+            }
+        };
+        configuration.sessionDelivery = delivery;
+
+        // Add callback which returns false to suppress sending
+        sessionTracker.addOnSession(new OnSession() {
+            @Override
+            public Boolean onSession(SessionPayload payload) {
+                return false; // suppress delivery
+            }
+        });
+
+        // Start a session and flush far enough in future to trigger send attempt
+        sessionTracker.startSession(new Date(10000000L), false);
+        sessionTracker.flushSessions(new Date(13600000L)); // different batch period
+
+        // Verify delivery was NOT performed
+        assertFalse(delivery.delivered);
+        assertEquals(0, delivery.count.get());
+    }
+
     abstract static class CustomDelivery implements Delivery {
         boolean delivered;
         AtomicInteger count = new AtomicInteger(0);

--- a/bugsnag/src/test/java/com/bugsnag/SessionTrackerTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/SessionTrackerTest.java
@@ -337,7 +337,7 @@ public class SessionTrackerTest {
         // Add callback which returns false to suppress sending
         sessionTracker.addOnSession(new OnSession() {
             @Override
-            public Boolean onSession(SessionPayload payload) {
+            public boolean onSession(SessionPayload payload) {
                 return false; // suppress delivery
             }
         });

--- a/examples/logback/src/main/java/com/bugsnag/example/logback/cli/Application.java
+++ b/examples/logback/src/main/java/com/bugsnag/example/logback/cli/Application.java
@@ -16,7 +16,8 @@ public class Application {
 
     public static void main(String[] args) throws Exception {
 
-        ch.qos.logback.classic.Logger rootLogger = (ch.qos.logback.classic.Logger)LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+        ch.qos.logback.classic.Logger rootLogger = (ch.qos.logback.classic.Logger) LoggerFactory
+                .getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         Appender appender = rootLogger.getAppender("BUGSNAG");
         if (appender instanceof BugsnagAppender) {
             // Set some global meta data (added to each report)
@@ -28,6 +29,7 @@ public class Application {
                 report.setUserName("User Name");
                 report.setUserEmail("user@example.com");
                 report.setUserId("12345");
+                return true;
             });
         }
 
@@ -58,6 +60,7 @@ public class Application {
             LOGGER.warn(new BugsnagMarker((report) -> {
                 report.addToTab("report tab", "data key 1", "data value 1");
                 report.addToTab("report tab", "data key 2", "data value 2");
+                return true;
             }), "Something bad happened", e);
         }
 
@@ -76,7 +79,8 @@ public class Application {
         // Wait for unhandled exception thread to finish before exiting
         thread.join();
 
-        // Remove the thread metadata so it won't be added to future reports on this thread
+        // Remove the thread metadata so it won't be added to future reports on this
+        // thread
         Bugsnag.clearThreadMetadata();
 
         // Exit the application

--- a/examples/simple/src/main/java/com/bugsnag/example/simple/ExampleApp.java
+++ b/examples/simple/src/main/java/com/bugsnag/example/simple/ExampleApp.java
@@ -22,7 +22,7 @@ public class ExampleApp {
         // the lifecyle of your application
         bugsnag.addCallback(new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.addToTab("diagnostics", "timestamp", new Date());
                 report.addToTab("customer", "name", "acme-inc");
                 report.addToTab("customer", "paying", true);
@@ -53,7 +53,7 @@ public class ExampleApp {
         } catch (RuntimeException e) {
             bugsnag.notify(e, new Callback() {
                 @Override
-                public void beforeNotify(Report report) {
+                public void onError(Report report) {
                     report.setSeverity(Severity.WARNING);
                     report.addToTab("report", "something", "that happened");
                     report.setContext("the context");

--- a/examples/simple/src/main/java/com/bugsnag/example/simple/ExampleApp.java
+++ b/examples/simple/src/main/java/com/bugsnag/example/simple/ExampleApp.java
@@ -22,7 +22,7 @@ public class ExampleApp {
         // the lifecyle of your application
         bugsnag.addCallback(new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.addToTab("diagnostics", "timestamp", new Date());
                 report.addToTab("customer", "name", "acme-inc");
                 report.addToTab("customer", "paying", true);
@@ -30,6 +30,7 @@ public class ExampleApp {
                 report.setUserName("User Name");
                 report.setUserEmail("user@example.com");
                 report.setUserId("12345");
+                return true;
             }
         });
 
@@ -53,10 +54,11 @@ public class ExampleApp {
         } catch (RuntimeException e) {
             bugsnag.notify(e, new Callback() {
                 @Override
-                public void onError(Report report) {
+                public Boolean onError(Report report) {
                     report.setSeverity(Severity.WARNING);
                     report.addToTab("report", "something", "that happened");
                     report.setContext("the context");
+                    return true;
                 }
             });
         }

--- a/examples/simple/src/main/java/com/bugsnag/example/simple/ExampleApp.java
+++ b/examples/simple/src/main/java/com/bugsnag/example/simple/ExampleApp.java
@@ -22,7 +22,7 @@ public class ExampleApp {
         // the lifecyle of your application
         bugsnag.addCallback(new Callback() {
             @Override
-            public Boolean onError(Report report) {
+            public boolean onError(Report report) {
                 report.addToTab("diagnostics", "timestamp", new Date());
                 report.addToTab("customer", "name", "acme-inc");
                 report.addToTab("customer", "paying", true);
@@ -54,7 +54,7 @@ public class ExampleApp {
         } catch (RuntimeException e) {
             bugsnag.notify(e, new Callback() {
                 @Override
-                public Boolean onError(Report report) {
+                public boolean onError(Report report) {
                     report.setSeverity(Severity.WARNING);
                     report.addToTab("report", "something", "that happened");
                     report.setContext("the context");

--- a/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/ApplicationRestController.java
+++ b/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/ApplicationRestController.java
@@ -71,7 +71,7 @@ public class ApplicationRestController {
         } catch (RuntimeException e) {
             bugsnag.notify(e, new Callback() {
                 @Override
-                public void beforeNotify(Report report) {
+                public void onError(Report report) {
                     report.setSeverity(Severity.WARNING);
                     report.addToTab("report", "something", "that happened");
                     report.setContext("the context");

--- a/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/ApplicationRestController.java
+++ b/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/ApplicationRestController.java
@@ -71,7 +71,7 @@ public class ApplicationRestController {
         } catch (RuntimeException e) {
             bugsnag.notify(e, new Callback() {
                 @Override
-                public Boolean onError(Report report) {
+                public boolean onError(Report report) {
                     report.setSeverity(Severity.WARNING);
                     report.addToTab("report", "something", "that happened");
                     report.setContext("the context");

--- a/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/ApplicationRestController.java
+++ b/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/ApplicationRestController.java
@@ -71,10 +71,11 @@ public class ApplicationRestController {
         } catch (RuntimeException e) {
             bugsnag.notify(e, new Callback() {
                 @Override
-                public void onError(Report report) {
+                public Boolean onError(Report report) {
                     report.setSeverity(Severity.WARNING);
                     report.addToTab("report", "something", "that happened");
                     report.setContext("the context");
+                    return true;
                 }
             });
         }

--- a/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Config.java
+++ b/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Config.java
@@ -31,7 +31,7 @@ public class Config {
         // the lifecyle of your application
         bugsnag.addCallback(new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.addToTab("diagnostics", "timestamp", new Date());
                 report.addToTab("customer", "name", "acme-inc");
                 report.addToTab("customer", "paying", true);

--- a/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Config.java
+++ b/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Config.java
@@ -31,7 +31,7 @@ public class Config {
         // the lifecyle of your application
         bugsnag.addCallback(new Callback() {
             @Override
-            public Boolean onError(Report report) {
+            public boolean onError(Report report) {
                 report.addToTab("diagnostics", "timestamp", new Date());
                 report.addToTab("customer", "name", "acme-inc");
                 report.addToTab("customer", "paying", true);

--- a/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Config.java
+++ b/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Config.java
@@ -31,7 +31,7 @@ public class Config {
         // the lifecyle of your application
         bugsnag.addCallback(new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.addToTab("diagnostics", "timestamp", new Date());
                 report.addToTab("customer", "name", "acme-inc");
                 report.addToTab("customer", "paying", true);
@@ -39,6 +39,7 @@ public class Config {
                 report.setUserName("User Name");
                 report.setUserEmail("user@example.com");
                 report.setUserId("12345");
+                return true;
             }
         });
 

--- a/examples/spring/src/main/java/com/bugsnag/example/spring/cli/ApplicationCommandLineRunner.java
+++ b/examples/spring/src/main/java/com/bugsnag/example/spring/cli/ApplicationCommandLineRunner.java
@@ -50,7 +50,7 @@ public class ApplicationCommandLineRunner implements CommandLineRunner {
         } catch (RuntimeException e) {
             bugsnag.notify(e, new Callback() {
                 @Override
-                public void beforeNotify(Report report) {
+                public void onError(Report report) {
                     report.setSeverity(Severity.WARNING);
                     report.addToTab("report", "something", "that happened");
                     report.setContext("the context");

--- a/examples/spring/src/main/java/com/bugsnag/example/spring/cli/ApplicationCommandLineRunner.java
+++ b/examples/spring/src/main/java/com/bugsnag/example/spring/cli/ApplicationCommandLineRunner.java
@@ -50,7 +50,7 @@ public class ApplicationCommandLineRunner implements CommandLineRunner {
         } catch (RuntimeException e) {
             bugsnag.notify(e, new Callback() {
                 @Override
-                public Boolean onError(Report report) {
+                public boolean onError(Report report) {
                     report.setSeverity(Severity.WARNING);
                     report.addToTab("report", "something", "that happened");
                     report.setContext("the context");

--- a/examples/spring/src/main/java/com/bugsnag/example/spring/cli/ApplicationCommandLineRunner.java
+++ b/examples/spring/src/main/java/com/bugsnag/example/spring/cli/ApplicationCommandLineRunner.java
@@ -50,10 +50,11 @@ public class ApplicationCommandLineRunner implements CommandLineRunner {
         } catch (RuntimeException e) {
             bugsnag.notify(e, new Callback() {
                 @Override
-                public void onError(Report report) {
+                public Boolean onError(Report report) {
                     report.setSeverity(Severity.WARNING);
                     report.addToTab("report", "something", "that happened");
                     report.setContext("the context");
+                    return true;
                 }
             });
         }

--- a/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Config.java
+++ b/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Config.java
@@ -32,7 +32,7 @@ public class Config {
         // the lifecyle of your application
         bugsnag.addCallback(new Callback() {
             @Override
-            public Boolean onError(Report report) {
+            public boolean onError(Report report) {
                 report.addToTab("diagnostics", "timestamp", new Date());
                 report.addToTab("customer", "name", "acme-inc");
                 report.addToTab("customer", "paying", true);

--- a/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Config.java
+++ b/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Config.java
@@ -31,7 +31,7 @@ public class Config {
         // the lifecyle of your application
         bugsnag.addCallback(new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.addToTab("diagnostics", "timestamp", new Date());
                 report.addToTab("customer", "name", "acme-inc");
                 report.addToTab("customer", "paying", true);

--- a/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Config.java
+++ b/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Config.java
@@ -15,7 +15,8 @@ import java.util.Date;
 @Import(BugsnagSpringConfiguration.class)
 public class Config {
 
-    // Define singleton bean "bugsnag" which can be injected into any Spring managed class with @Autowired.
+    // Define singleton bean "bugsnag" which can be injected into any Spring managed
+    // class with @Autowired.
     @Bean
     public Bugsnag bugsnag() {
         // Create a Bugsnag client
@@ -31,7 +32,7 @@ public class Config {
         // the lifecyle of your application
         bugsnag.addCallback(new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.addToTab("diagnostics", "timestamp", new Date());
                 report.addToTab("customer", "name", "acme-inc");
                 report.addToTab("customer", "paying", true);
@@ -39,6 +40,7 @@ public class Config {
                 report.setUserName("User Name");
                 report.setUserEmail("user@example.com");
                 report.setUserId("12345");
+                return true;
             }
         });
 

--- a/features/fixtures/mazerunnerspringboot3/src/main/java/com/bugsnag/mazerunner/scenarios/ScheduledTaskExecutorScenario.java
+++ b/features/fixtures/mazerunnerspringboot3/src/main/java/com/bugsnag/mazerunner/scenarios/ScheduledTaskExecutorScenario.java
@@ -27,9 +27,10 @@ public class ScheduledTaskExecutorScenario extends Scenario {
         final Collection<String> threadnames = ScheduledTaskExecutorService.getThreadNames();
         bugsnag.notify(new RuntimeException("Whoops"), new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.addToTab("executor", "multiThreaded", threadnames.size() > 1);
                 report.addToTab("executor", "names", threadnames);
+                return true;
             }
         });
     }

--- a/features/fixtures/mazerunnerspringboot3/src/main/java/com/bugsnag/mazerunner/scenarios/ScheduledTaskExecutorScenario.java
+++ b/features/fixtures/mazerunnerspringboot3/src/main/java/com/bugsnag/mazerunner/scenarios/ScheduledTaskExecutorScenario.java
@@ -27,7 +27,7 @@ public class ScheduledTaskExecutorScenario extends Scenario {
         final Collection<String> threadnames = ScheduledTaskExecutorService.getThreadNames();
         bugsnag.notify(new RuntimeException("Whoops"), new Callback() {
             @Override
-            public Boolean onError(Report report) {
+            public boolean onError(Report report) {
                 report.addToTab("executor", "multiThreaded", threadnames.size() > 1);
                 report.addToTab("executor", "names", threadnames);
                 return true;

--- a/features/fixtures/mazerunnerspringboot3/src/main/java/com/bugsnag/mazerunner/scenarios/ScheduledTaskExecutorScenario.java
+++ b/features/fixtures/mazerunnerspringboot3/src/main/java/com/bugsnag/mazerunner/scenarios/ScheduledTaskExecutorScenario.java
@@ -27,7 +27,7 @@ public class ScheduledTaskExecutorScenario extends Scenario {
         final Collection<String> threadnames = ScheduledTaskExecutorService.getThreadNames();
         bugsnag.notify(new RuntimeException("Whoops"), new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.addToTab("executor", "multiThreaded", threadnames.size() > 1);
                 report.addToTab("executor", "names", threadnames);
             }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/AutoRedactScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/AutoRedactScenario.java
@@ -17,7 +17,7 @@ public class AutoRedactScenario extends Scenario {
     public void run() {
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public Boolean onError(Report report) {
+            public boolean onError(Report report) {
                 report.addToTab("user", "password", "hunter2");
                 report.addToTab("custom", "password", "hunter2");
                 report.addToTab("custom", "foo", "hunter2");

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/AutoRedactScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/AutoRedactScenario.java
@@ -17,10 +17,11 @@ public class AutoRedactScenario extends Scenario {
     public void run() {
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.addToTab("user", "password", "hunter2");
                 report.addToTab("custom", "password", "hunter2");
                 report.addToTab("custom", "foo", "hunter2");
+                return true;
             }
         });
     }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/AutoRedactScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/AutoRedactScenario.java
@@ -17,7 +17,7 @@ public class AutoRedactScenario extends Scenario {
     public void run() {
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.addToTab("user", "password", "hunter2");
                 report.addToTab("custom", "password", "hunter2");
                 report.addToTab("custom", "foo", "hunter2");

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/LogbackMetadataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/LogbackMetadataScenario.java
@@ -22,12 +22,13 @@ public class LogbackMetadataScenario extends Scenario {
     @Override
     public void run() {
         LOGGER.warn(new BugsnagMarker(new Callback() {
-                    @Override
-                    public void onError(Report report) {
-                        report.addToTab("user", "foo", "hunter2");
-                        report.addToTab("custom", "foo", "hunter2");
-                        report.addToTab("custom", "bar", "hunter2");
-                    }
-                }),"Error sent to Bugsnag using the logback appender", generateException());
+            @Override
+            public Boolean onError(Report report) {
+                report.addToTab("user", "foo", "hunter2");
+                report.addToTab("custom", "foo", "hunter2");
+                report.addToTab("custom", "bar", "hunter2");
+                return true;
+            }
+        }), "Error sent to Bugsnag using the logback appender", generateException());
     }
 }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/LogbackMetadataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/LogbackMetadataScenario.java
@@ -23,7 +23,7 @@ public class LogbackMetadataScenario extends Scenario {
     public void run() {
         LOGGER.warn(new BugsnagMarker(new Callback() {
                     @Override
-                    public void beforeNotify(Report report) {
+                    public void onError(Report report) {
                         report.addToTab("user", "foo", "hunter2");
                         report.addToTab("custom", "foo", "hunter2");
                         report.addToTab("custom", "bar", "hunter2");

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/LogbackMetadataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/LogbackMetadataScenario.java
@@ -23,7 +23,7 @@ public class LogbackMetadataScenario extends Scenario {
     public void run() {
         LOGGER.warn(new BugsnagMarker(new Callback() {
             @Override
-            public Boolean onError(Report report) {
+            public boolean onError(Report report) {
                 report.addToTab("user", "foo", "hunter2");
                 report.addToTab("custom", "foo", "hunter2");
                 report.addToTab("custom", "bar", "hunter2");

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ManualContextScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ManualContextScenario.java
@@ -17,7 +17,7 @@ public class ManualContextScenario extends Scenario {
     public void run() {
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.setContext("FooContext");
             }
         });

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ManualContextScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ManualContextScenario.java
@@ -17,8 +17,9 @@ public class ManualContextScenario extends Scenario {
     public void run() {
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.setContext("FooContext");
+                return true;
             }
         });
     }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ManualContextScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ManualContextScenario.java
@@ -17,7 +17,7 @@ public class ManualContextScenario extends Scenario {
     public void run() {
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public Boolean onError(Report report) {
+            public boolean onError(Report report) {
                 report.setContext("FooContext");
                 return true;
             }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ManualRedactScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ManualRedactScenario.java
@@ -20,10 +20,11 @@ public class ManualRedactScenario extends Scenario {
 
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.addToTab("user", "foo", "hunter2");
                 report.addToTab("custom", "foo", "hunter2");
                 report.addToTab("custom", "bar", "hunter2");
+                return true;
             }
         });
     }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ManualRedactScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ManualRedactScenario.java
@@ -20,7 +20,7 @@ public class ManualRedactScenario extends Scenario {
 
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public Boolean onError(Report report) {
+            public boolean onError(Report report) {
                 report.addToTab("user", "foo", "hunter2");
                 report.addToTab("custom", "foo", "hunter2");
                 report.addToTab("custom", "bar", "hunter2");

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ManualRedactScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ManualRedactScenario.java
@@ -20,7 +20,7 @@ public class ManualRedactScenario extends Scenario {
 
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.addToTab("user", "foo", "hunter2");
                 report.addToTab("custom", "foo", "hunter2");
                 report.addToTab("custom", "bar", "hunter2");

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/MetadataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/MetadataScenario.java
@@ -17,7 +17,7 @@ public class MetadataScenario extends Scenario {
     public void run() {
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public Boolean onError(Report report) {
+            public boolean onError(Report report) {
                 report.addToTab("Custom", "foo", "Hello World!");
                 return true;
             }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/MetadataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/MetadataScenario.java
@@ -17,8 +17,9 @@ public class MetadataScenario extends Scenario {
     public void run() {
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.addToTab("Custom", "foo", "Hello World!");
+                return true;
             }
         });
     }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/MetadataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/MetadataScenario.java
@@ -17,7 +17,7 @@ public class MetadataScenario extends Scenario {
     public void run() {
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.addToTab("Custom", "foo", "Hello World!");
             }
         });

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ThreadMetadataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ThreadMetadataScenario.java
@@ -18,7 +18,7 @@ public class ThreadMetadataScenario extends Scenario {
         // Global callback metadata has lowest precedence
         bugsnag.addCallback(new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.addToTab("Custom", "test", "Global value");
                 report.addToTab("Custom", "foo", "Global value to be overwritten");
             }
@@ -47,7 +47,7 @@ public class ThreadMetadataScenario extends Scenario {
         // Report-specific metadata should merge with global + thread metadata and overwrite when duplicate key
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.addToTab("Custom", "bar", "Hello World!");
             }
         });

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ThreadMetadataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ThreadMetadataScenario.java
@@ -18,9 +18,10 @@ public class ThreadMetadataScenario extends Scenario {
         // Global callback metadata has lowest precedence
         bugsnag.addCallback(new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.addToTab("Custom", "test", "Global value");
                 report.addToTab("Custom", "foo", "Global value to be overwritten");
+                return true;
             }
         });
 
@@ -47,8 +48,9 @@ public class ThreadMetadataScenario extends Scenario {
         // Report-specific metadata should merge with global + thread metadata and overwrite when duplicate key
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.addToTab("Custom", "bar", "Hello World!");
+                return true;
             }
         });
     }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ThreadMetadataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ThreadMetadataScenario.java
@@ -18,7 +18,7 @@ public class ThreadMetadataScenario extends Scenario {
         // Global callback metadata has lowest precedence
         bugsnag.addCallback(new Callback() {
             @Override
-            public Boolean onError(Report report) {
+            public boolean onError(Report report) {
                 report.addToTab("Custom", "test", "Global value");
                 report.addToTab("Custom", "foo", "Global value to be overwritten");
                 return true;
@@ -48,7 +48,7 @@ public class ThreadMetadataScenario extends Scenario {
         // Report-specific metadata should merge with global + thread metadata and overwrite when duplicate key
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public Boolean onError(Report report) {
+            public boolean onError(Report report) {
                 report.addToTab("Custom", "bar", "Hello World!");
                 return true;
             }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UnhandledThreadMetadataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UnhandledThreadMetadataScenario.java
@@ -18,7 +18,7 @@ public class UnhandledThreadMetadataScenario extends Scenario {
         // Global callback metadata has lowest precedence
         bugsnag.addCallback(new Callback() {
             @Override
-            public Boolean onError(Report report) {
+            public boolean onError(Report report) {
                 report.addToTab("Custom", "test", "Global value");
                 report.addToTab("Custom", "foo", "Global value to be overwritten");
                 return true;

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UnhandledThreadMetadataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UnhandledThreadMetadataScenario.java
@@ -18,9 +18,10 @@ public class UnhandledThreadMetadataScenario extends Scenario {
         // Global callback metadata has lowest precedence
         bugsnag.addCallback(new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.addToTab("Custom", "test", "Global value");
                 report.addToTab("Custom", "foo", "Global value to be overwritten");
+                return true;
             }
         });
 

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UnhandledThreadMetadataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UnhandledThreadMetadataScenario.java
@@ -18,7 +18,7 @@ public class UnhandledThreadMetadataScenario extends Scenario {
         // Global callback metadata has lowest precedence
         bugsnag.addCallback(new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.addToTab("Custom", "test", "Global value");
                 report.addToTab("Custom", "foo", "Global value to be overwritten");
             }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UserCallbackScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UserCallbackScenario.java
@@ -17,7 +17,7 @@ public class UserCallbackScenario extends Scenario {
     public void run() {
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public Boolean onError(Report report) {
+            public boolean onError(Report report) {
                 report.setUser("Agent Pink", "bob@example.com", "Zebedee");
                 return true;
             }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UserCallbackScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UserCallbackScenario.java
@@ -17,8 +17,9 @@ public class UserCallbackScenario extends Scenario {
     public void run() {
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public void onError(Report report) {
+            public Boolean onError(Report report) {
                 report.setUser("Agent Pink", "bob@example.com", "Zebedee");
+                return true;
             }
         });
     }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UserCallbackScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UserCallbackScenario.java
@@ -17,7 +17,7 @@ public class UserCallbackScenario extends Scenario {
     public void run() {
         bugsnag.notify(generateException(), new Callback() {
             @Override
-            public void beforeNotify(Report report) {
+            public void onError(Report report) {
                 report.setUser("Agent Pink", "bob@example.com", "Zebedee");
             }
         });


### PR DESCRIPTION
Rename `beforeNotify` -> `onError` and `beforeSendSession` -> `onSession`
Make callbacks return a bool so that sessions and events can be vetoed