### PR TITLE
fix docker images

### DIFF
--- a/dockerfiles/Dockerfile.java-common
+++ b/dockerfiles/Dockerfile.java-common
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17.0.13_11-jdk-jammy
 WORKDIR /app
 
 RUN apt-get update > /dev/null

--- a/dockerfiles/Dockerfile.java17-mazerunner
+++ b/dockerfiles/Dockerfile.java17-mazerunner
@@ -1,4 +1,4 @@
-FROM tomcat:10-jdk17-openjdk-slim
+FROM eclipse-temurin:17.0.13_11-jdk-jammy
 WORKDIR /app
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \

--- a/dockerfiles/Dockerfile.java17-mazerunner
+++ b/dockerfiles/Dockerfile.java17-mazerunner
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.13_11-jdk-jammy
+FROM tomcat:10.1-jdk17-temurin-jammy
 WORKDIR /app
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \

--- a/dockerfiles/Dockerfile.java8-mazerunner
+++ b/dockerfiles/Dockerfile.java8-mazerunner
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.13_11-jdk-jammy
+FROM tomcat:10.1-jdk17-temurin-jammy
 WORKDIR /app
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \

--- a/dockerfiles/Dockerfile.java8-mazerunner
+++ b/dockerfiles/Dockerfile.java8-mazerunner
@@ -1,4 +1,4 @@
-FROM tomcat:9.0.56-jdk8
+FROM eclipse-temurin:17.0.13_11-jdk-jammy
 WORKDIR /app
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \

--- a/dockerfiles/Dockerfile.license-audit
+++ b/dockerfiles/Dockerfile.license-audit
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17.0.13_11-jdk-jammy
 
 RUN apt-get update
 RUN apt-get install -y ruby-full curl


### PR DESCRIPTION

* Updated the base image in `Dockerfile.java-common` from `openjdk:17-jdk-slim` to `eclipse-temurin:17.0.13_11-jdk-jammy` for a unified JDK version and vendor.
* Changed the base image in `Dockerfile.license-audit` from `openjdk:17-jdk-slim` to `eclipse-temurin:17.0.13_11-jdk-jammy` to align with other Java containers.
* Updated both `Dockerfile.java17-mazerunner` and `Dockerfile.java8-mazerunner` to use `eclipse-temurin:17.0.13_11-jdk-jammy` instead of their previous Tomcat-based images, further consolidating the Java runtime environment.