### PR TITLE
Minor Configuration improvements

### DIFF
--- a/bugsnag/src/main/java/com/bugsnag/Configuration.java
+++ b/bugsnag/src/main/java/com/bugsnag/Configuration.java
@@ -20,8 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 @SuppressWarnings("visibilitymodifier")
 public class Configuration {
@@ -45,9 +44,9 @@ public class Configuration {
     private boolean sendThreads = false;
     private Serializer serializer = new DefaultSerializer();
 
-    Collection<Callback> callbacks = new ConcurrentLinkedQueue<Callback>();
-    private final AtomicBoolean autoCaptureSessions = new AtomicBoolean(true);
-    private final AtomicBoolean sendUncaughtExceptions = new AtomicBoolean(true);
+    final Collection<Callback> callbacks = new CopyOnWriteArraySet<>();
+    private volatile boolean autoCaptureSessions = true;
+    private volatile boolean sendUncaughtExceptions = true;
 
     Configuration(String apiKey) {
         this.apiKey = apiKey;
@@ -101,19 +100,19 @@ public class Configuration {
     }
 
     public void setAutoCaptureSessions(boolean autoCaptureSessions) {
-        this.autoCaptureSessions.set(autoCaptureSessions);
+        this.autoCaptureSessions = autoCaptureSessions;
     }
 
     public boolean shouldAutoCaptureSessions() {
-        return autoCaptureSessions.get();
+        return autoCaptureSessions;
     }
 
     public void setSendUncaughtExceptions(boolean sendUncaughtExceptions) {
-        this.sendUncaughtExceptions.set(sendUncaughtExceptions);
+        this.sendUncaughtExceptions = sendUncaughtExceptions;
     }
 
     public boolean shouldSendUncaughtExceptions() {
-        return sendUncaughtExceptions.get();
+        return sendUncaughtExceptions;
     }
 
     /**
@@ -161,10 +160,10 @@ public class Configuration {
         boolean invalidSessionsEndpoint = sessions == null || sessions.isEmpty();
         String sessionEndpoint = null;
 
-        if (invalidSessionsEndpoint && this.autoCaptureSessions.get()) {
+        if (invalidSessionsEndpoint && this.autoCaptureSessions) {
             LOGGER.warn("The session tracking endpoint has not been"
                     + " set. Session tracking is disabled");
-            this.autoCaptureSessions.set(false);
+            this.autoCaptureSessions = false;
         } else {
             sessionEndpoint = sessions;
         }


### PR DESCRIPTION
## Goal
Minor internal simplifications to `Configuration`

## Changeset

- `callbacks` is now `final` and implemented as a `CopyOnWriteArraySet` avoiding the overheads of a `ConcurrentLinkedQueue` during iteration

- `autoCaptureSessions` and `sendUncaughtExceptions` changed from `AtomicBoolean` to `volatile boolean` since we weren't using any of the atomic semantics

## Testing
Relied on existing tests