### PR TITLE
Notifier spec refactoring

### DIFF
--- a/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
@@ -28,7 +28,7 @@ public class BugsnagSpringConfiguration implements InitializingBean {
     Callback springVersionErrorCallback() {
         Callback callback = new Callback() {
             @Override
-            public boolean onError(Report report) {
+            public boolean onError(Event report) {
                 addSpringRuntimeVersion(report.getDevice());
                 return true;
             }

--- a/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
@@ -1,6 +1,6 @@
 package com.bugsnag;
 
-import com.bugsnag.callbacks.Callback;
+import com.bugsnag.callbacks.OnErrorCallback;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,15 +25,15 @@ public class BugsnagSpringConfiguration implements InitializingBean {
      * Add a callback to add the version of Spring used by the application
      */
     @Bean
-    Callback springVersionErrorCallback() {
-        Callback callback = new Callback() {
+    OnErrorCallback springVersionErrorCallback() {
+        OnErrorCallback callback = new OnErrorCallback() {
             @Override
             public boolean onError(BugsnagEvent report) {
                 addSpringRuntimeVersion(report.getDevice());
                 return true;
             }
         };
-        bugsnag.addCallback(callback);
+        bugsnag.addOnError(callback);
         return callback;
     }
 

--- a/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/BugsnagSpringConfiguration.java
@@ -28,7 +28,7 @@ public class BugsnagSpringConfiguration implements InitializingBean {
     Callback springVersionErrorCallback() {
         Callback callback = new Callback() {
             @Override
-            public boolean onError(Event report) {
+            public boolean onError(BugsnagEvent report) {
                 addSpringRuntimeVersion(report.getDevice());
                 return true;
             }

--- a/bugsnag-spring/src/main/java/com/bugsnag/ExceptionClassCallback.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/ExceptionClassCallback.java
@@ -111,9 +111,9 @@ class ExceptionClassCallback implements Callback {
     }
 
     @Override
-    public boolean onError(Report report) {
+    public boolean onError(Event event) {
 
-        HandledState handledState = report.getHandledState();
+        HandledState handledState = event.getHandledState();
 
         // A manually-set severity takes precedence
         SeverityReasonType severityReasonType = handledState.calculateSeverityReasonType();
@@ -122,12 +122,12 @@ class ExceptionClassCallback implements Callback {
             return true; // do not change delivery decision
         }
 
-        Class exceptionClass = report.getException().getClass();
+        Class exceptionClass = event.getException().getClass();
 
         if (EXCEPTION_TO_SEVERITY.containsKey(exceptionClass)) {
             Severity severity = EXCEPTION_TO_SEVERITY.get(exceptionClass);
-            report.setSeverity(severity);
-            report.setHandledState(HandledState.newInstance(
+            event.setSeverity(severity);
+            event.setHandledState(HandledState.newInstance(
                     SeverityReasonType.REASON_EXCEPTION_CLASS,
                     Collections.singletonMap("exceptionClass", exceptionClass.getSimpleName()),
                     severity,

--- a/bugsnag-spring/src/main/java/com/bugsnag/ExceptionClassCallback.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/ExceptionClassCallback.java
@@ -1,7 +1,7 @@
 package com.bugsnag;
 
 import com.bugsnag.HandledState.SeverityReasonType;
-import com.bugsnag.callbacks.Callback;
+import com.bugsnag.callbacks.OnErrorCallback;
 
 import org.springframework.beans.ConversionNotSupportedException;
 import org.springframework.beans.TypeMismatchException;
@@ -35,7 +35,7 @@ import java.util.Map;
  * Exceptions that automatically resolve to 500 (internal server error) responses
  * map to severity to ERROR.
  */
-class ExceptionClassCallback implements Callback {
+class ExceptionClassCallback implements OnErrorCallback {
 
     private static final Map<Class<? extends java.lang.Exception>, Severity> EXCEPTION_TO_SEVERITY;
 

--- a/bugsnag-spring/src/main/java/com/bugsnag/ExceptionClassCallback.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/ExceptionClassCallback.java
@@ -111,7 +111,7 @@ class ExceptionClassCallback implements Callback {
     }
 
     @Override
-    public boolean onError(Event event) {
+    public boolean onError(BugsnagEvent event) {
 
         HandledState handledState = event.getHandledState();
 

--- a/bugsnag-spring/src/main/java/com/bugsnag/JakartaMvcConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/JakartaMvcConfiguration.java
@@ -30,6 +30,6 @@ class JakartaMvcConfiguration implements InitializingBean {
      */
     @Override
     public void afterPropertiesSet() {
-        bugsnag.addCallback(new ExceptionClassCallback());
+        bugsnag.addOnError(new ExceptionClassCallback());
     }
 }

--- a/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
@@ -1,6 +1,6 @@
 package com.bugsnag;
 
-import com.bugsnag.callbacks.Callback;
+import com.bugsnag.callbacks.OnErrorCallback;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootVersion;
@@ -16,15 +16,15 @@ public class SpringBootConfiguration {
      * Add a callback to add the version of Spring Boot used by the application.
      */
     @Bean
-    Callback springBootVersionErrorCallback() {
-        Callback callback = new Callback() {
+    OnErrorCallback springBootVersionErrorCallback() {
+        OnErrorCallback callback = new OnErrorCallback() {
             @Override
             public boolean onError(BugsnagEvent report) {
                 addSpringRuntimeVersion(report.getDevice());
                 return true;
             }
         };
-        bugsnag.addCallback(callback);
+        bugsnag.addOnError(callback);
         return callback;
     }
 

--- a/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
@@ -19,7 +19,7 @@ public class SpringBootConfiguration {
     Callback springBootVersionErrorCallback() {
         Callback callback = new Callback() {
             @Override
-            public boolean onError(Report report) {
+            public boolean onError(Event report) {
                 addSpringRuntimeVersion(report.getDevice());
                 return true;
             }

--- a/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
+++ b/bugsnag-spring/src/main/java/com/bugsnag/SpringBootConfiguration.java
@@ -19,7 +19,7 @@ public class SpringBootConfiguration {
     Callback springBootVersionErrorCallback() {
         Callback callback = new Callback() {
             @Override
-            public boolean onError(Event report) {
+            public boolean onError(BugsnagEvent report) {
                 addSpringRuntimeVersion(report.getDevice());
                 return true;
             }

--- a/bugsnag-spring/src/test/java/com/bugsnag/NotifierTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/NotifierTest.java
@@ -11,7 +11,7 @@ import java.util.Collections;
 
 public class NotifierTest {
 
-    private Event event;
+    private BugsnagEvent event;
     private Configuration config;
     private SessionPayload sessionPayload;
 
@@ -23,7 +23,7 @@ public class NotifierTest {
     @Before
     public void setUp() throws Throwable {
         config = new Configuration("api-key");
-        event = new Event(config, new RuntimeException());
+        event = new BugsnagEvent(config, new RuntimeException());
         sessionPayload = new SessionPayload(Collections.<SessionCount>emptyList(), config);
     }
 

--- a/bugsnag-spring/src/test/java/com/bugsnag/NotifierTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/NotifierTest.java
@@ -11,7 +11,7 @@ import java.util.Collections;
 
 public class NotifierTest {
 
-    private Report report;
+    private Event event;
     private Configuration config;
     private SessionPayload sessionPayload;
 
@@ -23,13 +23,13 @@ public class NotifierTest {
     @Before
     public void setUp() throws Throwable {
         config = new Configuration("api-key");
-        report = new Report(config, new RuntimeException());
+        event = new Event(config, new RuntimeException());
         sessionPayload = new SessionPayload(Collections.<SessionCount>emptyList(), config);
     }
 
     @Test
     public void testNotificationSerialisation() throws Throwable {
-        JsonNode payload = BugsnagTestUtils.mapReportToJson(config, this.report);
+        JsonNode payload = BugsnagTestUtils.mapReportToJson(config, this.event);
         JsonNode notifier = payload.get("notifier");
 
         assertEquals("Bugsnag Spring", notifier.get("name").asText());

--- a/bugsnag-spring/src/test/java/com/bugsnag/SpringAsyncTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/SpringAsyncTest.java
@@ -50,41 +50,41 @@ public class SpringAsyncTest {
     public void bugsnagNotifyWhenAsyncVoidReturnTypeException() {
         asyncService.throwExceptionVoid();
 
-        Report report = verifyAndGetReport(delivery);
+        Event event = verifyAndGetReport(delivery);
 
         // Assert that the exception was detected correctly
-        assertEquals("Async void test", report.getExceptionMessage());
-        assertEquals("java.lang.RuntimeException", report.getExceptionName());
+        assertEquals("Async void test", event.getExceptionMessage());
+        assertEquals("java.lang.RuntimeException", event.getExceptionName());
 
         // Assert that the severity, severity reason and unhandled values are correct
-        assertEquals(Severity.ERROR.getValue(), report.getSeverity());
+        assertEquals(Severity.ERROR.getValue(), event.getSeverity());
         assertEquals(
                 SeverityReasonType.REASON_UNHANDLED_EXCEPTION_MIDDLEWARE.toString(),
-                report.getSeverityReason().getType());
+                event.getSeverityReason().getType());
         assertThat(
-                report.getSeverityReason().getAttributes(),
+                event.getSeverityReason().getAttributes(),
                 is(Collections.singletonMap("framework", "Spring")));
-        assertTrue(report.getUnhandled());
+        assertTrue(event.getUnhandled());
     }
 
     @Test
     public void bugsnagNotifyWhenAsyncFutureReturnTypeException() {
         asyncService.throwExceptionFuture();
 
-        Report report = verifyAndGetReport(delivery);
+        Event event = verifyAndGetReport(delivery);
 
         // Assert that the exception was detected correctly
-        assertEquals("Async future test", report.getExceptionMessage());
-        assertEquals("java.lang.RuntimeException", report.getExceptionName());
+        assertEquals("Async future test", event.getExceptionMessage());
+        assertEquals("java.lang.RuntimeException", event.getExceptionName());
 
         // Assert that the severity, severity reason and unhandled values are correct
-        assertEquals(Severity.ERROR.getValue(), report.getSeverity());
+        assertEquals(Severity.ERROR.getValue(), event.getSeverity());
         assertEquals(
                 SeverityReasonType.REASON_UNHANDLED_EXCEPTION_MIDDLEWARE.toString(),
-                report.getSeverityReason().getType());
+                event.getSeverityReason().getType());
         assertThat(
-                report.getSeverityReason().getAttributes(),
+                event.getSeverityReason().getAttributes(),
                 is(Collections.singletonMap("framework", "Spring")));
-        assertTrue(report.getUnhandled());
+        assertTrue(event.getUnhandled());
     }
 }

--- a/bugsnag-spring/src/test/java/com/bugsnag/SpringAsyncTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/SpringAsyncTest.java
@@ -50,7 +50,7 @@ public class SpringAsyncTest {
     public void bugsnagNotifyWhenAsyncVoidReturnTypeException() {
         asyncService.throwExceptionVoid();
 
-        Event event = verifyAndGetReport(delivery);
+        BugsnagEvent event = verifyAndGetReport(delivery);
 
         // Assert that the exception was detected correctly
         assertEquals("Async void test", event.getExceptionMessage());
@@ -71,7 +71,7 @@ public class SpringAsyncTest {
     public void bugsnagNotifyWhenAsyncFutureReturnTypeException() {
         asyncService.throwExceptionFuture();
 
-        Event event = verifyAndGetReport(delivery);
+        BugsnagEvent event = verifyAndGetReport(delivery);
 
         // Assert that the exception was detected correctly
         assertEquals("Async future test", event.getExceptionMessage());

--- a/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import com.bugsnag.HandledState.SeverityReasonType;
 
-import com.bugsnag.callbacks.Callback;
+import com.bugsnag.callbacks.OnErrorCallback;
 import com.bugsnag.delivery.Delivery;
 
 import com.bugsnag.serialization.Serializer;
@@ -188,7 +188,7 @@ public class SpringMvcTest {
     public void unhandledTypeMismatchExceptionCallbackSeverity()
             throws IllegalAccessException, NoSuchFieldException {
         BugsnagEvent event;
-        Callback callback = new Callback() {
+        OnErrorCallback callback = new OnErrorCallback() {
             @Override
             public boolean onError(BugsnagEvent report) {
                 report.setSeverity(Severity.WARNING);
@@ -197,7 +197,7 @@ public class SpringMvcTest {
         };
 
         try {
-            bugsnag.addCallback(callback);
+            bugsnag.addOnError(callback);
 
             callUnhandledTypeMismatchExceptionEndpoint();
 
@@ -205,8 +205,8 @@ public class SpringMvcTest {
         } finally {
             // Remove the callback via reflection so that subsequent tests do not use it
             Field callbacksField = Configuration.class.getDeclaredField("callbacks");
-            @SuppressWarnings(value = "unchecked") Collection<Callback> callbacks =
-                    (Collection<Callback>) callbacksField.get(bugsnag.getConfig());
+            @SuppressWarnings(value = "unchecked") Collection<OnErrorCallback> callbacks =
+                    (Collection<OnErrorCallback>) callbacksField.get(bugsnag.getConfig());
             callbacks.remove(callback);
         }
 

--- a/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
@@ -83,21 +83,21 @@ public class SpringMvcTest {
     public void bugsnagNotifyWhenUncaughtControllerException() {
         callRuntimeExceptionEndpoint();
 
-        Report report = verifyAndGetReport(delivery);
+        Event event = verifyAndGetReport(delivery);
 
         // Assert that the exception was detected correctly
-        assertEquals("Test", report.getExceptionMessage());
-        assertEquals("java.lang.RuntimeException", report.getExceptionName());
+        assertEquals("Test", event.getExceptionMessage());
+        assertEquals("java.lang.RuntimeException", event.getExceptionName());
 
         // Assert that the severity, severity reason and unhandled values are correct
-        assertEquals(Severity.ERROR.getValue(), report.getSeverity());
+        assertEquals(Severity.ERROR.getValue(), event.getSeverity());
         assertEquals(
                 SeverityReasonType.REASON_UNHANDLED_EXCEPTION_MIDDLEWARE.toString(),
-                report.getSeverityReason().getType());
+                event.getSeverityReason().getType());
         assertThat(
-                report.getSeverityReason().getAttributes(),
+                event.getSeverityReason().getAttributes(),
                 is(Collections.singletonMap("framework", "Spring")));
-        assertTrue(report.getUnhandled());
+        assertTrue(event.getUnhandled());
     }
 
     @Test
@@ -129,14 +129,14 @@ public class SpringMvcTest {
     public void requestMetadataSetCorrectly() {
         callRuntimeExceptionEndpoint();
 
-        Report report = verifyAndGetReport(delivery);
+        Event event = verifyAndGetReport(delivery);
 
         // Check that the context is set to the HTTP method and URI of the endpoint
-        assertEquals("GET /throw-runtime-exception", report.getContext());
+        assertEquals("GET /throw-runtime-exception", event.getContext());
 
         // Check that the request metadata is set as expected
         @SuppressWarnings(value = "unchecked") Map<String, Object> requestMetadata =
-                (Map<String, Object>) report.getMetadata().get("request");
+                (Map<String, Object>) event.getMetadata().get("request");
         assertEquals("http://localhost:" + randomServerPort + "/throw-runtime-exception",
                 requestMetadata.get("url"));
         assertEquals("GET", requestMetadata.get("method"));
@@ -161,10 +161,10 @@ public class SpringMvcTest {
     public void springVersionSetCorrectly() {
         callRuntimeExceptionEndpoint();
 
-        Report report = verifyAndGetReport(delivery);
+        Event event = verifyAndGetReport(delivery);
 
         // Check that the Spring version is set as expected
-        Map<String, Object> deviceMetadata = report.getDevice();
+        Map<String, Object> deviceMetadata = event.getDevice();
         Map<String, Object> runtimeVersions =
                 (Map<String, Object>) deviceMetadata.get("runtimeVersions");
         assertEquals(SpringVersion.getVersion(), runtimeVersions.get("springFramework"));
@@ -175,22 +175,22 @@ public class SpringMvcTest {
     public void unhandledTypeMismatchExceptionSeverityInfo() {
         callUnhandledTypeMismatchExceptionEndpoint();
 
-        Report report = verifyAndGetReport(delivery);
+        Event event = verifyAndGetReport(delivery);
 
-        assertTrue(report.getUnhandled());
-        assertEquals("info", report.getSeverity());
-        assertEquals("exceptionClass", report.getSeverityReason().getType());
-        assertThat(report.getSeverityReason().getAttributes(),
+        assertTrue(event.getUnhandled());
+        assertEquals("info", event.getSeverity());
+        assertEquals("exceptionClass", event.getSeverityReason().getType());
+        assertThat(event.getSeverityReason().getAttributes(),
                 is(Collections.singletonMap("exceptionClass", "TypeMismatchException")));
     }
 
     @Test
     public void unhandledTypeMismatchExceptionCallbackSeverity()
             throws IllegalAccessException, NoSuchFieldException {
-        Report report;
+        Event event;
         Callback callback = new Callback() {
             @Override
-            public boolean onError(Report report) {
+            public boolean onError(Event report) {
                 report.setSeverity(Severity.WARNING);
                 return true;
             }
@@ -201,7 +201,7 @@ public class SpringMvcTest {
 
             callUnhandledTypeMismatchExceptionEndpoint();
 
-            report = verifyAndGetReport(delivery);
+            event = verifyAndGetReport(delivery);
         } finally {
             // Remove the callback via reflection so that subsequent tests do not use it
             Field callbacksField = Configuration.class.getDeclaredField("callbacks");
@@ -210,32 +210,32 @@ public class SpringMvcTest {
             callbacks.remove(callback);
         }
 
-        assertTrue(report.getUnhandled());
-        assertEquals("warning", report.getSeverity());
-        assertEquals("userCallbackSetSeverity", report.getSeverityReason().getType());
+        assertTrue(event.getUnhandled());
+        assertEquals("warning", event.getSeverity());
+        assertEquals("userCallbackSetSeverity", event.getSeverityReason().getType());
     }
 
     @Test
     public void handledTypeMismatchExceptionUserSeverity() {
         callHandledTypeMismatchExceptionUserSeverityEndpoint();
 
-        Report report = verifyAndGetReport(delivery);
+        Event event = verifyAndGetReport(delivery);
 
-        assertFalse(report.getUnhandled());
-        assertEquals("warning", report.getSeverity());
-        assertEquals("userSpecifiedSeverity", report.getSeverityReason().getType());
-        assertThat(report.getSeverityReason().getAttributes(), is(Collections.EMPTY_MAP));
+        assertFalse(event.getUnhandled());
+        assertEquals("warning", event.getSeverity());
+        assertEquals("userSpecifiedSeverity", event.getSeverityReason().getType());
+        assertThat(event.getSeverityReason().getAttributes(), is(Collections.EMPTY_MAP));
     }
 
     @Test
     public void handledTypeMismatchExceptionCallbackSeverity() {
         callHandledTypeMismatchExceptionCallbackSeverityEndpoint();
 
-        Report report = verifyAndGetReport(delivery);
+        Event event = verifyAndGetReport(delivery);
 
-        assertFalse(report.getUnhandled());
-        assertEquals("warning", report.getSeverity());
-        assertEquals("userCallbackSetSeverity", report.getSeverityReason().getType());
+        assertFalse(event.getUnhandled());
+        assertEquals("warning", event.getSeverity());
+        assertEquals("userCallbackSetSeverity", event.getSeverityReason().getType());
     }
 
     private void callUnhandledTypeMismatchExceptionEndpoint() {

--- a/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/SpringMvcTest.java
@@ -83,7 +83,7 @@ public class SpringMvcTest {
     public void bugsnagNotifyWhenUncaughtControllerException() {
         callRuntimeExceptionEndpoint();
 
-        Event event = verifyAndGetReport(delivery);
+        BugsnagEvent event = verifyAndGetReport(delivery);
 
         // Assert that the exception was detected correctly
         assertEquals("Test", event.getExceptionMessage());
@@ -129,7 +129,7 @@ public class SpringMvcTest {
     public void requestMetadataSetCorrectly() {
         callRuntimeExceptionEndpoint();
 
-        Event event = verifyAndGetReport(delivery);
+        BugsnagEvent event = verifyAndGetReport(delivery);
 
         // Check that the context is set to the HTTP method and URI of the endpoint
         assertEquals("GET /throw-runtime-exception", event.getContext());
@@ -161,7 +161,7 @@ public class SpringMvcTest {
     public void springVersionSetCorrectly() {
         callRuntimeExceptionEndpoint();
 
-        Event event = verifyAndGetReport(delivery);
+        BugsnagEvent event = verifyAndGetReport(delivery);
 
         // Check that the Spring version is set as expected
         Map<String, Object> deviceMetadata = event.getDevice();
@@ -175,7 +175,7 @@ public class SpringMvcTest {
     public void unhandledTypeMismatchExceptionSeverityInfo() {
         callUnhandledTypeMismatchExceptionEndpoint();
 
-        Event event = verifyAndGetReport(delivery);
+        BugsnagEvent event = verifyAndGetReport(delivery);
 
         assertTrue(event.getUnhandled());
         assertEquals("info", event.getSeverity());
@@ -187,10 +187,10 @@ public class SpringMvcTest {
     @Test
     public void unhandledTypeMismatchExceptionCallbackSeverity()
             throws IllegalAccessException, NoSuchFieldException {
-        Event event;
+        BugsnagEvent event;
         Callback callback = new Callback() {
             @Override
-            public boolean onError(Event report) {
+            public boolean onError(BugsnagEvent report) {
                 report.setSeverity(Severity.WARNING);
                 return true;
             }
@@ -219,7 +219,7 @@ public class SpringMvcTest {
     public void handledTypeMismatchExceptionUserSeverity() {
         callHandledTypeMismatchExceptionUserSeverityEndpoint();
 
-        Event event = verifyAndGetReport(delivery);
+        BugsnagEvent event = verifyAndGetReport(delivery);
 
         assertFalse(event.getUnhandled());
         assertEquals("warning", event.getSeverity());
@@ -231,7 +231,7 @@ public class SpringMvcTest {
     public void handledTypeMismatchExceptionCallbackSeverity() {
         callHandledTypeMismatchExceptionCallbackSeverityEndpoint();
 
-        Event event = verifyAndGetReport(delivery);
+        BugsnagEvent event = verifyAndGetReport(delivery);
 
         assertFalse(event.getUnhandled());
         assertEquals("warning", event.getSeverity());

--- a/bugsnag-spring/src/test/java/com/bugsnag/SpringScheduledTaskTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/SpringScheduledTaskTest.java
@@ -70,21 +70,21 @@ public class SpringScheduledTaskTest {
         // Run the task now and wait for it to finish
         scheduler.submit(exampleRunnable).get();
 
-        Report report = verifyAndGetReport(delivery);
+        Event event = verifyAndGetReport(delivery);
 
         // Assert that the exception was detected correctly
-        assertEquals("Scheduled test", report.getExceptionMessage());
-        assertEquals("java.lang.RuntimeException", report.getExceptionName());
+        assertEquals("Scheduled test", event.getExceptionMessage());
+        assertEquals("java.lang.RuntimeException", event.getExceptionName());
 
         // Assert that the severity, severity reason and unhandled values are correct
-        assertEquals(Severity.ERROR.getValue(), report.getSeverity());
+        assertEquals(Severity.ERROR.getValue(), event.getSeverity());
         assertEquals(
                 SeverityReasonType.REASON_UNHANDLED_EXCEPTION_MIDDLEWARE.toString(),
-                report.getSeverityReason().getType());
+                event.getSeverityReason().getType());
         assertThat(
-                report.getSeverityReason().getAttributes(),
+                event.getSeverityReason().getAttributes(),
                 is(Collections.singletonMap("framework", "Spring")));
-        assertTrue(report.getUnhandled());
+        assertTrue(event.getUnhandled());
 
         // Assert that the exception is passed to an existing exception handler
         ArgumentCaptor<RuntimeException> exceptionCaptor =

--- a/bugsnag-spring/src/test/java/com/bugsnag/SpringScheduledTaskTest.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/SpringScheduledTaskTest.java
@@ -70,7 +70,7 @@ public class SpringScheduledTaskTest {
         // Run the task now and wait for it to finish
         scheduler.submit(exampleRunnable).get();
 
-        Event event = verifyAndGetReport(delivery);
+        BugsnagEvent event = verifyAndGetReport(delivery);
 
         // Assert that the exception was detected correctly
         assertEquals("Scheduled test", event.getExceptionMessage());

--- a/bugsnag-spring/src/test/java/com/bugsnag/TestUtils.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/TestUtils.java
@@ -16,7 +16,7 @@ class TestUtils {
     /**
      * Verify that a report was received, then capture and return that report
      */
-    static Event verifyAndGetReport(Delivery delivery) {
+    static BugsnagEvent verifyAndGetReport(Delivery delivery) {
         ArgumentCaptor<Notification> notificationCaptor =
                 ArgumentCaptor.forClass(Notification.class);
         verify(delivery, timeout(100).times(1)).deliver(

--- a/bugsnag-spring/src/test/java/com/bugsnag/TestUtils.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/TestUtils.java
@@ -16,7 +16,7 @@ class TestUtils {
     /**
      * Verify that a report was received, then capture and return that report
      */
-    static Report verifyAndGetReport(Delivery delivery) {
+    static Event verifyAndGetReport(Delivery delivery) {
         ArgumentCaptor<Notification> notificationCaptor =
                 ArgumentCaptor.forClass(Notification.class);
         verify(delivery, timeout(100).times(1)).deliver(

--- a/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestController.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestController.java
@@ -2,7 +2,7 @@ package com.bugsnag.testapp.springboot;
 
 import com.bugsnag.Bugsnag;
 
-import com.bugsnag.Event;
+import com.bugsnag.BugsnagEvent;
 import com.bugsnag.Severity;
 import com.bugsnag.callbacks.Callback;
 
@@ -67,7 +67,7 @@ public class TestController {
         } catch (TypeMismatchException ex) {
             bugsnag.notify(ex, new Callback() {
                 @Override
-                public boolean onError(Event event) {
+                public boolean onError(BugsnagEvent event) {
                     event.setSeverity(Severity.WARNING);
                     return true;
                 }

--- a/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestController.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestController.java
@@ -2,7 +2,7 @@ package com.bugsnag.testapp.springboot;
 
 import com.bugsnag.Bugsnag;
 
-import com.bugsnag.Report;
+import com.bugsnag.Event;
 import com.bugsnag.Severity;
 import com.bugsnag.callbacks.Callback;
 
@@ -67,8 +67,8 @@ public class TestController {
         } catch (TypeMismatchException ex) {
             bugsnag.notify(ex, new Callback() {
                 @Override
-                public boolean onError(Report report) {
-                    report.setSeverity(Severity.WARNING);
+                public boolean onError(Event event) {
+                    event.setSeverity(Severity.WARNING);
                     return true;
                 }
             });

--- a/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestController.java
+++ b/bugsnag-spring/src/test/java/com/bugsnag/testapp/springboot/TestController.java
@@ -4,7 +4,7 @@ import com.bugsnag.Bugsnag;
 
 import com.bugsnag.BugsnagEvent;
 import com.bugsnag.Severity;
-import com.bugsnag.callbacks.Callback;
+import com.bugsnag.callbacks.OnErrorCallback;
 
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,7 +65,7 @@ public class TestController {
         try {
             throw new TypeMismatchException("Test", String.class);
         } catch (TypeMismatchException ex) {
-            bugsnag.notify(ex, new Callback() {
+            bugsnag.notify(ex, new OnErrorCallback() {
                 @Override
                 public boolean onError(BugsnagEvent event) {
                     event.setSeverity(Severity.WARNING);

--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -349,13 +349,13 @@ public class Bugsnag implements Closeable {
      *
      * @param throwable the exception to send to Bugsnag
      * @return the report object
-     * @see Report
-     * @see #notify(com.bugsnag.Report)
+     * @see Event
+     * @see #notify(Event)
      */
-    public Report buildReport(Throwable throwable) {
+    public Event buildReport(Throwable throwable) {
         HandledState handledState = HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_HANDLED_EXCEPTION);
-        return new Report(config, throwable, handledState, Thread.currentThread(), featureFlagStore);
+        return new Event(config, throwable, handledState, Thread.currentThread(), featureFlagStore);
     }
 
     /**
@@ -411,48 +411,48 @@ public class Bugsnag implements Closeable {
 
         HandledState handledState = HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_USER_SPECIFIED, severity);
-        Report report = new Report(config, throwable, handledState, Thread.currentThread(), featureFlagStore);
-        return notify(report, callback);
+        Event event = new Event(config, throwable, handledState, Thread.currentThread(), featureFlagStore);
+        return notify(event, callback);
     }
 
     /**
      * Notify Bugsnag of an exception and provide custom diagnostic data
      * for this particular error report.
      *
-     * @param report the {@link Report} object to send to Bugsnag
+     * @param event the {@link Event} object to send to Bugsnag
      * @return true unless the error report was ignored
-     * @see Report
+     * @see Event
      * @see #buildReport
      */
-    public boolean notify(Report report) {
-        return notify(report, null);
+    public boolean notify(Event event) {
+        return notify(event, null);
     }
 
     boolean notify(Throwable throwable, HandledState handledState, Thread currentThread) {
-        Report report = new Report(config, throwable, handledState, currentThread, featureFlagStore);
-        return notify(report, null);
+        Event event = new Event(config, throwable, handledState, currentThread, featureFlagStore);
+        return notify(event, null);
     }
 
     /**
      * Notify Bugsnag of an exception and provide custom diagnostic data
      * for this particular error report.
      *
-     * @param report         the {@link Report} object to send to Bugsnag
+     * @param event         the {@link Event} object to send to Bugsnag
      * @param reportCallback the {@link Callback} object to run for this Report
      * @return false if the error report was ignored
-     * @see Report
+     * @see Event
      * @see #buildReport
      */
-    public boolean notify(Report report, Callback reportCallback) {
-        if (report == null) {
+    public boolean notify(Event event, Callback reportCallback) {
+        if (event == null) {
             LOGGER.warn("Tried to call notify with a null Report");
             return false;
         }
 
         // Don't notify if this error class should be ignored
-        if (config.shouldIgnoreClass(report.getExceptionName())) {
+        if (config.shouldIgnoreClass(event.getExceptionName())) {
             LOGGER.debug("Error not reported to Bugsnag - {} is in 'discardClasses'",
-                    report.getExceptionName());
+                    event.getExceptionName());
             return false;
         }
 
@@ -466,8 +466,8 @@ public class Bugsnag implements Closeable {
         // Run all client-wide onError callbacks
         for (Callback callback : config.callbacks) {
             try {
-                boolean proceed = callback.onError(report);
-                if (!proceed || report.getShouldCancel()) {
+                boolean proceed = callback.onError(event);
+                if (!proceed || event.getShouldCancel()) {
                     LOGGER.debug("Error not reported to Bugsnag - cancelled by a client-wide onError callback");
                     return false;
                 }
@@ -477,13 +477,13 @@ public class Bugsnag implements Closeable {
         }
 
         // Add thread metadata to the report
-        report.mergeMetadata(THREAD_METADATA.get());
+        event.mergeMetadata(THREAD_METADATA.get());
 
         // Run the report-specific onError callback, if given
         if (reportCallback != null) {
             try {
-                boolean proceed = reportCallback.onError(report);
-                if (!proceed || report.getShouldCancel()) {
+                boolean proceed = reportCallback.onError(event);
+                if (!proceed || event.getShouldCancel()) {
                     LOGGER.debug("Error not reported to Bugsnag - cancelled by a report-specific callback");
                     return false;
                 }
@@ -502,16 +502,16 @@ public class Bugsnag implements Closeable {
         Session session = sessionTracker.getSession();
 
         if (session != null) {
-            if (report.getUnhandled()) {
+            if (event.getUnhandled()) {
                 session.incrementUnhandledCount();
             } else {
                 session.incrementHandledCount();
             }
-            report.setSession(session);
+            event.setSession(session);
         }
 
         // Build the notification
-        Notification notification = new Notification(config, report);
+        Notification notification = new Notification(config, event);
 
         // Deliver the notification
         LOGGER.debug("Reporting error to Bugsnag");

--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -122,7 +122,7 @@ public class Bugsnag implements Closeable {
     }
 
     private void addSessionTrackingShutdownHook() {
-        Runtime.getRuntime().addShutdownHook(new java.lang.Thread() {
+        Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
                 close();
@@ -353,7 +353,7 @@ public class Bugsnag implements Closeable {
     public BugsnagEvent buildReport(Throwable throwable) {
         HandledState handledState = HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_HANDLED_EXCEPTION);
-        return new BugsnagEvent(config, throwable, handledState, java.lang.Thread.currentThread(), featureFlagStore);
+        return new BugsnagEvent(config, throwable, handledState, Thread.currentThread(), featureFlagStore);
     }
 
     /**
@@ -408,8 +408,17 @@ public class Bugsnag implements Closeable {
         }
 
         HandledState handledState = HandledState.newInstance(
-                HandledState.SeverityReasonType.REASON_USER_SPECIFIED, severity);
-        BugsnagEvent event = new BugsnagEvent(config, throwable, handledState, java.lang.Thread.currentThread(), featureFlagStore);
+                HandledState.SeverityReasonType.REASON_USER_SPECIFIED,
+                severity
+        );
+
+        BugsnagEvent event = new BugsnagEvent(
+                config,
+                throwable,
+                handledState,
+                Thread.currentThread(),
+                featureFlagStore
+        );
         return notify(event, callback);
     }
 
@@ -426,7 +435,7 @@ public class Bugsnag implements Closeable {
         return notify(event, null);
     }
 
-    boolean notify(Throwable throwable, HandledState handledState, java.lang.Thread currentThread) {
+    boolean notify(Throwable throwable, HandledState handledState, Thread currentThread) {
         BugsnagEvent event = new BugsnagEvent(config, throwable, handledState, currentThread, featureFlagStore);
         return notify(event, null);
     }
@@ -673,7 +682,7 @@ public class Bugsnag implements Closeable {
      * @return clients which catch uncaught exceptions
      */
     public static Set<Bugsnag> uncaughtExceptionClients() {
-        UncaughtExceptionHandler handler = java.lang.Thread.getDefaultUncaughtExceptionHandler();
+        UncaughtExceptionHandler handler = Thread.getDefaultUncaughtExceptionHandler();
         if (handler instanceof ExceptionHandler) {
             ExceptionHandler bugsnagHandler = (ExceptionHandler) handler;
             return Collections.unmodifiableSet(bugsnagHandler.uncaughtExceptionClients());

--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -308,15 +308,13 @@ public class Bugsnag implements Closeable {
     }
 
     /**
-     * Set whether Bugsnag should capture and report thread-state for all
-     * running threads. This is often not useful for Java web apps, since
-     * there could be thousands of active threads depending on your
-     * environment.
+     * Set when Bugsnag should capture and report thread-state for all
+     * running threads.
      *
      * @param sendThreads should we send thread state with error reports
      * @see #setEnabledReleaseStages
      */
-    public void setSendThreads(boolean sendThreads) {
+    public void setSendThreads(ThreadSendPolicy sendThreads) {
         config.setSendThreads(sendThreads);
     }
 

--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -1,6 +1,6 @@
 package com.bugsnag;
 
-import com.bugsnag.callbacks.Callback;
+import com.bugsnag.callbacks.OnErrorCallback;
 import com.bugsnag.delivery.Delivery;
 import com.bugsnag.delivery.HttpDelivery;
 import com.bugsnag.util.DaemonThreadFactory;
@@ -142,10 +142,10 @@ public class Bugsnag implements Closeable {
      * sent to Bugsnag completely.
      *
      * @param callback a callback to run before sending errors to Bugsnag
-     * @see Callback
+     * @see OnErrorCallback
      */
-    public void addCallback(Callback callback) {
-        config.addCallback(callback);
+    public void addOnError(OnErrorCallback callback) {
+        config.addOnError(callback);
     }
 
     /**
@@ -370,10 +370,10 @@ public class Bugsnag implements Closeable {
      * Notify Bugsnag of a handled exception.
      *
      * @param throwable the exception to send to Bugsnag
-     * @param callback  the {@link Callback} object to run for this Report
+     * @param callback  the {@link OnErrorCallback} object to run for this Report
      * @return true unless the error report was ignored
      */
-    public boolean notify(Throwable throwable, Callback callback) {
+    public boolean notify(Throwable throwable, OnErrorCallback callback) {
         return notify(buildReport(throwable), callback);
     }
 
@@ -395,10 +395,10 @@ public class Bugsnag implements Closeable {
      * @param throwable the exception to send to Bugsnag
      * @param severity  the severity of the error, one of {#link Severity#ERROR},
      *                  {@link Severity#WARNING} or {@link Severity#INFO}
-     * @param callback  the {@link Callback} object to run for this Report
+     * @param callback  the {@link OnErrorCallback} object to run for this Report
      * @return true unless the error report was ignored
      */
-    public boolean notify(Throwable throwable, Severity severity, Callback callback) {
+    public boolean notify(Throwable throwable, Severity severity, OnErrorCallback callback) {
         if (throwable == null) {
             LOGGER.warn("Tried to notify with a null Throwable");
             return false;
@@ -436,12 +436,12 @@ public class Bugsnag implements Closeable {
      * for this particular error report.
      *
      * @param event         the {@link BugsnagEvent} object to send to Bugsnag
-     * @param reportCallback the {@link Callback} object to run for this Report
+     * @param reportCallback the {@link OnErrorCallback} object to run for this Report
      * @return false if the error report was ignored
      * @see BugsnagEvent
      * @see #buildReport
      */
-    public boolean notify(BugsnagEvent event, Callback reportCallback) {
+    public boolean notify(BugsnagEvent event, OnErrorCallback reportCallback) {
         if (event == null) {
             LOGGER.warn("Tried to call notify with a null Report");
             return false;
@@ -462,10 +462,10 @@ public class Bugsnag implements Closeable {
         }
 
         // Run all client-wide onError callbacks
-        for (Callback callback : config.callbacks) {
+        for (OnErrorCallback callback : config.callbacks) {
             try {
                 boolean proceed = callback.onError(event);
-                if (!proceed || event.getShouldCancel()) {
+                if (!proceed) {
                     LOGGER.debug("Error not reported to Bugsnag - cancelled by a client-wide onError callback");
                     return false;
                 }
@@ -481,7 +481,7 @@ public class Bugsnag implements Closeable {
         if (reportCallback != null) {
             try {
                 boolean proceed = reportCallback.onError(event);
-                if (!proceed || event.getShouldCancel()) {
+                if (!proceed) {
                     LOGGER.debug("Error not reported to Bugsnag - cancelled by a report-specific callback");
                     return false;
                 }

--- a/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
+++ b/bugsnag/src/main/java/com/bugsnag/Bugsnag.java
@@ -122,7 +122,7 @@ public class Bugsnag implements Closeable {
     }
 
     private void addSessionTrackingShutdownHook() {
-        Runtime.getRuntime().addShutdownHook(new Thread() {
+        Runtime.getRuntime().addShutdownHook(new java.lang.Thread() {
             @Override
             public void run() {
                 close();
@@ -349,13 +349,13 @@ public class Bugsnag implements Closeable {
      *
      * @param throwable the exception to send to Bugsnag
      * @return the report object
-     * @see Event
-     * @see #notify(Event)
+     * @see BugsnagEvent
+     * @see #notify(BugsnagEvent)
      */
-    public Event buildReport(Throwable throwable) {
+    public BugsnagEvent buildReport(Throwable throwable) {
         HandledState handledState = HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_HANDLED_EXCEPTION);
-        return new Event(config, throwable, handledState, Thread.currentThread(), featureFlagStore);
+        return new BugsnagEvent(config, throwable, handledState, java.lang.Thread.currentThread(), featureFlagStore);
     }
 
     /**
@@ -411,7 +411,7 @@ public class Bugsnag implements Closeable {
 
         HandledState handledState = HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_USER_SPECIFIED, severity);
-        Event event = new Event(config, throwable, handledState, Thread.currentThread(), featureFlagStore);
+        BugsnagEvent event = new BugsnagEvent(config, throwable, handledState, java.lang.Thread.currentThread(), featureFlagStore);
         return notify(event, callback);
     }
 
@@ -419,17 +419,17 @@ public class Bugsnag implements Closeable {
      * Notify Bugsnag of an exception and provide custom diagnostic data
      * for this particular error report.
      *
-     * @param event the {@link Event} object to send to Bugsnag
+     * @param event the {@link BugsnagEvent} object to send to Bugsnag
      * @return true unless the error report was ignored
-     * @see Event
+     * @see BugsnagEvent
      * @see #buildReport
      */
-    public boolean notify(Event event) {
+    public boolean notify(BugsnagEvent event) {
         return notify(event, null);
     }
 
-    boolean notify(Throwable throwable, HandledState handledState, Thread currentThread) {
-        Event event = new Event(config, throwable, handledState, currentThread, featureFlagStore);
+    boolean notify(Throwable throwable, HandledState handledState, java.lang.Thread currentThread) {
+        BugsnagEvent event = new BugsnagEvent(config, throwable, handledState, currentThread, featureFlagStore);
         return notify(event, null);
     }
 
@@ -437,13 +437,13 @@ public class Bugsnag implements Closeable {
      * Notify Bugsnag of an exception and provide custom diagnostic data
      * for this particular error report.
      *
-     * @param event         the {@link Event} object to send to Bugsnag
+     * @param event         the {@link BugsnagEvent} object to send to Bugsnag
      * @param reportCallback the {@link Callback} object to run for this Report
      * @return false if the error report was ignored
-     * @see Event
+     * @see BugsnagEvent
      * @see #buildReport
      */
-    public boolean notify(Event event, Callback reportCallback) {
+    public boolean notify(BugsnagEvent event, Callback reportCallback) {
         if (event == null) {
             LOGGER.warn("Tried to call notify with a null Report");
             return false;
@@ -675,7 +675,7 @@ public class Bugsnag implements Closeable {
      * @return clients which catch uncaught exceptions
      */
     public static Set<Bugsnag> uncaughtExceptionClients() {
-        UncaughtExceptionHandler handler = Thread.getDefaultUncaughtExceptionHandler();
+        UncaughtExceptionHandler handler = java.lang.Thread.getDefaultUncaughtExceptionHandler();
         if (handler instanceof ExceptionHandler) {
             ExceptionHandler bugsnagHandler = (ExceptionHandler) handler;
             return Collections.unmodifiableSet(bugsnagHandler.uncaughtExceptionClients());

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
@@ -138,19 +138,19 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
                         calculateSeverity(event),
                         new Callback() {
                             @Override
-                            public boolean onError(Report report) {
+                            public boolean onError(Event event) {
 
                                 // Add some data from the logging event
-                                report.addMetadata("Log event data",
+                                event.addMetadata("Log event data",
                                         "Message", event.getFormattedMessage());
-                                report.addMetadata("Log event data",
+                                event.addMetadata("Log event data",
                                         "Logger name", event.getLoggerName());
 
                                 // Add details from the logging context to the event
-                                populateContextData(report, event);
+                                populateContextData(event, event);
 
                                 if (reportCallback != null) {
-                                    boolean proceed = reportCallback.onError(report);
+                                    boolean proceed = reportCallback.onError(event);
                                     if (!proceed) {
                                         return false; // suppress delivery
                                     }
@@ -168,7 +168,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
      * @param report The report being sent to Bugsnag
      * @param event The logging event
      */
-    private void populateContextData(Report report, ILoggingEvent event) {
+    private void populateContextData(Event report, ILoggingEvent event) {
         Map<String, String> propertyMap = event.getMDCPropertyMap();
 
         if (propertyMap != null) {
@@ -283,12 +283,12 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         // Add a callback to put global metadata on every report
         bugsnag.addCallback(new Callback() {
             @Override
-            public boolean onError(Report report) {
+            public boolean onError(Event event) {
 
                 for (LogbackMetadata metadata : globalMetadata) {
                     for (LogbackMetadataTab tab : metadata.getTabs()) {
                         for (LogbackMetadataKey key : tab.getKeys()) {
-                            report.addMetadata(tab.getName(),
+                            event.addMetadata(tab.getName(),
                                     key.getName(),
                                     key.getValue());
                         }

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
@@ -116,12 +116,12 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     }
 
     @Override
-    protected void append(final ILoggingEvent event) {
+    protected void append(final ILoggingEvent loggingEvent) {
         if (bugsnag != null) {
-            Throwable throwable = extractThrowable(event);
+            Throwable throwable = extractThrowable(loggingEvent);
 
             final Callback reportCallback;
-            Marker marker = event.getMarker();
+            Marker marker = loggingEvent.getMarker();
             if (marker instanceof BugsnagMarker) {
                 reportCallback = ((BugsnagMarker) marker).getCallback();
             } else {
@@ -132,22 +132,22 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
             // from the this library and the logger is not in the list of excluded loggers.
             if (throwable != null
                     && !detectLogFromBugsnag(throwable)
-                    && !isExcludedLogger(event.getLoggerName())) {
+                    && !isExcludedLogger(loggingEvent.getLoggerName())) {
                 bugsnag.notify(
                         throwable,
-                        calculateSeverity(event),
+                        calculateSeverity(loggingEvent),
                         new Callback() {
                             @Override
-                            public boolean onError(Event event) {
+                            public boolean onError(BugsnagEvent event) {
 
                                 // Add some data from the logging event
                                 event.addMetadata("Log event data",
-                                        "Message", event.getFormattedMessage());
+                                        "Message", loggingEvent.getFormattedMessage());
                                 event.addMetadata("Log event data",
-                                        "Logger name", event.getLoggerName());
+                                        "Logger name", loggingEvent.getLoggerName());
 
                                 // Add details from the logging context to the event
-                                populateContextData(event, event);
+                                populateContextData(event, loggingEvent);
 
                                 if (reportCallback != null) {
                                     boolean proceed = reportCallback.onError(event);
@@ -168,7 +168,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
      * @param report The report being sent to Bugsnag
      * @param event The logging event
      */
-    private void populateContextData(Event report, ILoggingEvent event) {
+    private void populateContextData(BugsnagEvent report, ILoggingEvent event) {
         Map<String, String> propertyMap = event.getMDCPropertyMap();
 
         if (propertyMap != null) {
@@ -283,7 +283,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         // Add a callback to put global metadata on every report
         bugsnag.addCallback(new Callback() {
             @Override
-            public boolean onError(Event event) {
+            public boolean onError(BugsnagEvent event) {
 
                 for (LogbackMetadata metadata : globalMetadata) {
                     for (LogbackMetadataTab tab : metadata.getTabs()) {

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
@@ -1,6 +1,6 @@
 package com.bugsnag;
 
-import com.bugsnag.callbacks.Callback;
+import com.bugsnag.callbacks.OnErrorCallback;
 import com.bugsnag.delivery.Delivery;
 import com.bugsnag.logback.BugsnagMarker;
 import com.bugsnag.logback.LogbackFeatureFlag;
@@ -120,7 +120,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         if (bugsnag != null) {
             Throwable throwable = extractThrowable(loggingEvent);
 
-            final Callback reportCallback;
+            final OnErrorCallback reportCallback;
             Marker marker = loggingEvent.getMarker();
             if (marker instanceof BugsnagMarker) {
                 reportCallback = ((BugsnagMarker) marker).getCallback();
@@ -136,7 +136,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
                 bugsnag.notify(
                         throwable,
                         calculateSeverity(loggingEvent),
-                        new Callback() {
+                        new OnErrorCallback() {
                             @Override
                             public boolean onError(BugsnagEvent event) {
 
@@ -281,7 +281,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         }
 
         // Add a callback to put global metadata on every report
-        bugsnag.addCallback(new Callback() {
+        bugsnag.addOnError(new OnErrorCallback() {
             @Override
             public boolean onError(BugsnagEvent event) {
 
@@ -325,11 +325,11 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
      * sent to Bugsnag completely.
      *
      * @param callback a callback to run before sending errors to Bugsnag
-     * @see Callback
+     * @see OnErrorCallback
      */
-    public void addCallback(Callback callback) {
+    public void addCallback(OnErrorCallback callback) {
         if (bugsnag != null) {
-            bugsnag.addCallback(callback);
+            bugsnag.addOnError(callback);
         }
     }
 

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagAppender.java
@@ -69,7 +69,7 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     private String releaseStage;
 
     /** Whether thread state should be sent to Bugsnag. */
-    private boolean sendThreads = false;
+    private ThreadSendPolicy sendThreads = ThreadSendPolicy.NEVER;
 
     /** Bugsnag API request timeout. */
     private int timeout;
@@ -527,9 +527,9 @@ public class BugsnagAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     }
 
     /**
-     * @see Bugsnag#setSendThreads(boolean)
+     * @see Bugsnag#setSendThreads(ThreadSendPolicy)
      */
-    public void setSendThreads(boolean sendThreads) {
+    public void setSendThreads(ThreadSendPolicy sendThreads) {
         this.sendThreads = sendThreads;
 
         if (bugsnag != null) {

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagError.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagError.java
@@ -4,12 +4,12 @@ import com.bugsnag.serialization.Expose;
 
 import java.util.List;
 
-public class Error {
+public class BugsnagError {
     private Configuration config;
     private Throwable throwable;
     private String errorClass;
 
-    Error(Configuration config, Throwable throwable) {
+    BugsnagError(Configuration config, Throwable throwable) {
         this.config = config;
         this.throwable = throwable;
         this.errorClass = throwable.getClass().getName();

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagEvent.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagEvent.java
@@ -23,7 +23,6 @@ public class BugsnagEvent {
     private Severity severity;
     private String groupingHash;
     private Diagnostics diagnostics;
-    private boolean shouldCancel = false;
     private Map<String, Object> sessionMap;
     private final List<BugsnagThread> threads;
     private final FeatureFlagStore featureFlagStore;
@@ -332,15 +331,6 @@ public class BugsnagEvent {
     public BugsnagEvent setUserName(String name) {
         diagnostics.user.put("name", name);
         return this;
-    }
-
-    public BugsnagEvent cancel() {
-        this.shouldCancel = true;
-        return this;
-    }
-
-    public boolean getShouldCancel() {
-        return this.shouldCancel;
     }
 
     HandledState getHandledState() {

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagEvent.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagEvent.java
@@ -73,12 +73,16 @@ public class BugsnagEvent {
         return PAYLOAD_VERSION;
     }
 
+    @Expose
+    protected List<BugsnagError> getExceptions() {
+        return getErrors();
+    }
+
     /**
      * Get the exceptions for the report.
      *
      * @return the exceptions that make up the error.
      */
-    @Expose
     protected List<BugsnagError> getErrors() {
         List<BugsnagError> errors = new ArrayList<BugsnagError>();
         errors.add(error);

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagEvent.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagEvent.java
@@ -36,16 +36,16 @@ public class BugsnagEvent {
      */
     protected BugsnagEvent(Configuration config, Throwable throwable) {
         this(config, throwable, HandledState.newInstance(
-                HandledState.SeverityReasonType.REASON_HANDLED_EXCEPTION), java.lang.Thread.currentThread(), null);
+                HandledState.SeverityReasonType.REASON_HANDLED_EXCEPTION), Thread.currentThread(), null);
     }
 
     BugsnagEvent(Configuration config, Throwable throwable,
-                 HandledState handledState, java.lang.Thread currentThread) {
+                 HandledState handledState, Thread currentThread) {
         this(config, throwable, handledState, currentThread, null);
     }
 
     BugsnagEvent(Configuration config, Throwable throwable,
-                 HandledState handledState, java.lang.Thread currentThread, FeatureFlagStore clientFeatureFlagStore) {
+                 HandledState handledState, Thread currentThread, FeatureFlagStore clientFeatureFlagStore) {
         this.config = config;
         this.error = new BugsnagError(config, throwable);
         this.handledState = handledState;
@@ -58,9 +58,11 @@ public class BugsnagEvent {
             featureFlagStore.merge(clientFeatureFlagStore);
         }
 
-        if (config.isSendThreads()) {
+        boolean sendThreads = config.getSendThreads() == ThreadSendPolicy.ALWAYS ||
+                (config.getSendThreads() == ThreadSendPolicy.UNHANDLED_ONLY && handledState.isUnhandled());
+        if (sendThreads) {
             Throwable exc = handledState.isUnhandled() ? throwable : null;
-            Map<java.lang.Thread, StackTraceElement[]> allStackTraces = java.lang.Thread.getAllStackTraces();
+            Map<Thread, StackTraceElement[]> allStackTraces = Thread.getAllStackTraces();
             threads = BugsnagThread.getLiveThreads(config, currentThread, allStackTraces, exc);
         } else {
             threads = null;

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagEvent.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagEvent.java
@@ -11,21 +11,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class Event {
+public class BugsnagEvent {
 
     static final String PAYLOAD_VERSION = "4";
 
     private Configuration config;
 
     private String apiKey;
-    private final Error error;
+    private final BugsnagError error;
     private HandledState handledState;
     private Severity severity;
     private String groupingHash;
     private Diagnostics diagnostics;
     private boolean shouldCancel = false;
     private Map<String, Object> sessionMap;
-    private final List<ThreadState> threadStates;
+    private final List<BugsnagThread> threads;
     private final FeatureFlagStore featureFlagStore;
 
     /**
@@ -34,20 +34,20 @@ public class Event {
      * @param config    the configuration for the report.
      * @param throwable the error to create the report for.
      */
-    protected Event(Configuration config, Throwable throwable) {
+    protected BugsnagEvent(Configuration config, Throwable throwable) {
         this(config, throwable, HandledState.newInstance(
-                HandledState.SeverityReasonType.REASON_HANDLED_EXCEPTION), Thread.currentThread(), null);
+                HandledState.SeverityReasonType.REASON_HANDLED_EXCEPTION), java.lang.Thread.currentThread(), null);
     }
 
-    Event(Configuration config, Throwable throwable,
-          HandledState handledState, Thread currentThread) {
+    BugsnagEvent(Configuration config, Throwable throwable,
+                 HandledState handledState, java.lang.Thread currentThread) {
         this(config, throwable, handledState, currentThread, null);
     }
 
-    Event(Configuration config, Throwable throwable,
-          HandledState handledState, Thread currentThread, FeatureFlagStore clientFeatureFlagStore) {
+    BugsnagEvent(Configuration config, Throwable throwable,
+                 HandledState handledState, java.lang.Thread currentThread, FeatureFlagStore clientFeatureFlagStore) {
         this.config = config;
-        this.error = new Error(config, throwable);
+        this.error = new BugsnagError(config, throwable);
         this.handledState = handledState;
         this.severity = handledState.getOriginalSeverity();
         diagnostics = new Diagnostics(this.config);
@@ -60,10 +60,10 @@ public class Event {
 
         if (config.isSendThreads()) {
             Throwable exc = handledState.isUnhandled() ? throwable : null;
-            Map<Thread, StackTraceElement[]> allStackTraces = Thread.getAllStackTraces();
-            threadStates = ThreadState.getLiveThreads(config, currentThread, allStackTraces, exc);
+            Map<java.lang.Thread, StackTraceElement[]> allStackTraces = java.lang.Thread.getAllStackTraces();
+            threads = BugsnagThread.getLiveThreads(config, currentThread, allStackTraces, exc);
         } else {
-            threadStates = null;
+            threads = null;
         }
     }
 
@@ -78,13 +78,13 @@ public class Event {
      * @return the exceptions that make up the error.
      */
     @Expose
-    protected List<Error> getErrors() {
-        List<Error> errors = new ArrayList<Error>();
+    protected List<BugsnagError> getErrors() {
+        List<BugsnagError> errors = new ArrayList<BugsnagError>();
         errors.add(error);
 
         Throwable currentThrowable = error.getThrowable().getCause();
         while (currentThrowable != null) {
-            errors.add(new Error(config, currentThrowable));
+            errors.add(new BugsnagError(config, currentThrowable));
             currentThrowable = currentThrowable.getCause();
         }
 
@@ -103,8 +103,8 @@ public class Event {
     }
 
     @Expose
-    protected List<ThreadState> getThreads() {
-        return threadStates;
+    protected List<BugsnagThread> getThreads() {
+        return threads;
     }
 
     @Expose
@@ -202,7 +202,7 @@ public class Event {
      * @param value   the metadata value to add
      * @return the modified report
      */
-    public Event addMetadata(String tabName, String key, Object value) {
+    public BugsnagEvent addMetadata(String tabName, String key, Object value) {
         diagnostics.metadata.addMetadata(tabName, key, value);
         return this;
     }
@@ -213,7 +213,7 @@ public class Event {
      * @param tabName the name of the tab to clear.
      * @return The message from the exception contained in this error report.
      */
-    public Event clearTab(String tabName) {
+    public BugsnagEvent clearTab(String tabName) {
         diagnostics.metadata.clearMetadata(tabName);
         return this;
     }
@@ -227,7 +227,7 @@ public class Event {
      * @deprecated use {@link #addMetadata(String, String, Object)} instead
      */
     @Deprecated
-    public Event setAppInfo(String key, Object value) {
+    public BugsnagEvent setAppInfo(String key, Object value) {
         diagnostics.app.put(key, value);
         return this;
     }
@@ -238,7 +238,7 @@ public class Event {
      * @param apiKey the API key to use in the report
      * @return the modified report
      */
-    public Event setApiKey(String apiKey) {
+    public BugsnagEvent setApiKey(String apiKey) {
         this.apiKey = apiKey;
         return this;
     }
@@ -258,7 +258,7 @@ public class Event {
      * @param context the context to use in the report
      * @return the modified report
      */
-    public Event setContext(String context) {
+    public BugsnagEvent setContext(String context) {
         diagnostics.context = context;
         return this;
     }
@@ -272,7 +272,7 @@ public class Event {
      * @deprecated use {@link #addMetadata(String, String, Object)} instead
      */
     @Deprecated
-    public Event setDeviceInfo(String key, Object value) {
+    public BugsnagEvent setDeviceInfo(String key, Object value) {
         diagnostics.device.put(key, value);
         return this;
     }
@@ -285,7 +285,7 @@ public class Event {
      * @param groupingHash the grouping hash for the error report
      * @return the modified report
      */
-    public Event setGroupingHash(String groupingHash) {
+    public BugsnagEvent setGroupingHash(String groupingHash) {
         this.groupingHash = groupingHash;
         return this;
     }
@@ -296,7 +296,7 @@ public class Event {
      * @param severity the severity for the error report
      * @return the modified report
      */
-    public Event setSeverity(Severity severity) {
+    public BugsnagEvent setSeverity(Severity severity) {
         this.severity = severity;
         this.handledState.setCurrentSeverity(severity);
         return this;
@@ -310,29 +310,29 @@ public class Event {
      * @param name  the name of the user.
      * @return the modified report.
      */
-    public Event setUser(String id, String email, String name) {
+    public BugsnagEvent setUser(String id, String email, String name) {
         diagnostics.user.put("id", id);
         diagnostics.user.put("email", email);
         diagnostics.user.put("name", name);
         return this;
     }
 
-    public Event setUserId(String id) {
+    public BugsnagEvent setUserId(String id) {
         diagnostics.user.put("id", id);
         return this;
     }
 
-    public Event setUserEmail(String email) {
+    public BugsnagEvent setUserEmail(String email) {
         diagnostics.user.put("email", email);
         return this;
     }
 
-    public Event setUserName(String name) {
+    public BugsnagEvent setUserName(String name) {
         diagnostics.user.put("name", name);
         return this;
     }
 
-    public Event cancel() {
+    public BugsnagEvent cancel() {
         this.shouldCancel = true;
         return this;
     }
@@ -372,7 +372,7 @@ public class Event {
      * @param variant the feature flag variant (can be null)
      * @return the modified report
      */
-    public Event addFeatureFlag(String name, String variant) {
+    public BugsnagEvent addFeatureFlag(String name, String variant) {
         featureFlagStore.addFeatureFlag(name, variant);
         return this;
     }
@@ -383,7 +383,7 @@ public class Event {
      * @param name the feature flag name
      * @return the modified report
      */
-    public Event addFeatureFlag(String name) {
+    public BugsnagEvent addFeatureFlag(String name) {
         return addFeatureFlag(name, null);
     }
 
@@ -394,7 +394,7 @@ public class Event {
      * @param featureFlags the feature flags to add
      * @return the modified report
      */
-    public Event addFeatureFlags(Collection<FeatureFlag> featureFlags) {
+    public BugsnagEvent addFeatureFlags(Collection<FeatureFlag> featureFlags) {
         featureFlagStore.addFeatureFlags(featureFlags);
         return this;
     }
@@ -405,7 +405,7 @@ public class Event {
      * @param name the feature flag name to remove
      * @return the modified report
      */
-    public Event clearFeatureFlag(String name) {
+    public BugsnagEvent clearFeatureFlag(String name) {
         featureFlagStore.clearFeatureFlag(name);
         return this;
     }
@@ -415,7 +415,7 @@ public class Event {
      *
      * @return the modified report
      */
-    public Event clearFeatureFlags() {
+    public BugsnagEvent clearFeatureFlags() {
         featureFlagStore.clearFeatureFlags();
         return this;
     }

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagEvent.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagEvent.java
@@ -57,8 +57,8 @@ public class BugsnagEvent {
             featureFlagStore.merge(clientFeatureFlagStore);
         }
 
-        boolean sendThreads = config.getSendThreads() == ThreadSendPolicy.ALWAYS ||
-                (config.getSendThreads() == ThreadSendPolicy.UNHANDLED_ONLY && handledState.isUnhandled());
+        boolean sendThreads = config.getSendThreads() == ThreadSendPolicy.ALWAYS
+                || (config.getSendThreads() == ThreadSendPolicy.UNHANDLED_ONLY && handledState.isUnhandled());
         if (sendThreads) {
             Throwable exc = handledState.isUnhandled() ? throwable : null;
             Map<Thread, StackTraceElement[]> allStackTraces = Thread.getAllStackTraces();

--- a/bugsnag/src/main/java/com/bugsnag/BugsnagThread.java
+++ b/bugsnag/src/main/java/com/bugsnag/BugsnagThread.java
@@ -8,23 +8,23 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
-class ThreadState {
+public class BugsnagThread {
 
     private final Configuration config;
     private final Thread thread;
     private final StackTraceElement[] stackTraceElements;
     private Boolean errorReportingThread;
 
-    ThreadState(Configuration config, Thread thread, StackTraceElement[] stackTraceElements) {
+    BugsnagThread(Configuration config, Thread thread, StackTraceElement[] stackTraceElements) {
         this.config = config;
         this.thread = thread;
         this.stackTraceElements = stackTraceElements;
     }
 
-    static List<ThreadState> getLiveThreads(Configuration config,
-                                            Thread currentThread,
-                                            Map<Thread, StackTraceElement[]> liveThreads,
-                                            Throwable exc) {
+    static List<BugsnagThread> getLiveThreads(Configuration config,
+                                              Thread currentThread,
+                                              Map<Thread, StackTraceElement[]> liveThreads,
+                                              Throwable exc) {
         // Get current thread id (the crashing thread) and stacktraces for all live threads
         long crashingThreadId = currentThread.getId();
 
@@ -45,15 +45,15 @@ class ThreadState {
             }
         });
 
-        List<ThreadState> threads = new ArrayList<ThreadState>();
+        List<BugsnagThread> threads = new ArrayList<BugsnagThread>();
 
         for (Object key : keys) {
-            Thread thread = (Thread) key;
-            ThreadState threadState = new ThreadState(config, thread, liveThreads.get(thread));
-            threads.add(threadState);
+            Thread javaThread = (Thread) key;
+            BugsnagThread thread = new BugsnagThread(config, javaThread, liveThreads.get(javaThread));
+            threads.add(thread);
 
-            if (threadState.getId() == crashingThreadId) {
-                threadState.setErrorReportingThread(true);
+            if (thread.getId() == crashingThreadId) {
+                thread.setErrorReportingThread(true);
             }
         }
         return threads;

--- a/bugsnag/src/main/java/com/bugsnag/Configuration.java
+++ b/bugsnag/src/main/java/com/bugsnag/Configuration.java
@@ -20,7 +20,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 @SuppressWarnings("visibilitymodifier")
@@ -47,8 +46,8 @@ public class Configuration {
     private Serializer serializer = new DefaultSerializer();
 
     Set<OnErrorCallback> callbacks = new CopyOnWriteArraySet<>();
-    private final AtomicBoolean autoCaptureSessions = new AtomicBoolean(true);
-    private final AtomicBoolean sendUncaughtExceptions = new AtomicBoolean(true);
+    private volatile boolean autoCaptureSessions = true;
+    private volatile boolean sendUncaughtExceptions = true;
     private final FeatureFlagStore featureFlagStore = new FeatureFlagStore();
 
     Configuration(String apiKey) {
@@ -105,19 +104,19 @@ public class Configuration {
     }
 
     public void setAutoCaptureSessions(boolean autoCaptureSessions) {
-        this.autoCaptureSessions.set(autoCaptureSessions);
+        this.autoCaptureSessions = autoCaptureSessions;
     }
 
     public boolean shouldAutoCaptureSessions() {
-        return autoCaptureSessions.get();
+        return autoCaptureSessions;
     }
 
     public void setSendUncaughtExceptions(boolean sendUncaughtExceptions) {
-        this.sendUncaughtExceptions.set(sendUncaughtExceptions);
+        this.sendUncaughtExceptions = sendUncaughtExceptions;
     }
 
     public boolean shouldSendUncaughtExceptions() {
-        return sendUncaughtExceptions.get();
+        return sendUncaughtExceptions;
     }
 
     /**
@@ -165,10 +164,10 @@ public class Configuration {
         boolean invalidSessionsEndpoint = sessions == null || sessions.isEmpty();
         String sessionEndpoint = null;
 
-        if (invalidSessionsEndpoint && this.autoCaptureSessions.get()) {
+        if (invalidSessionsEndpoint && this.autoCaptureSessions) {
             LOGGER.warn("The session tracking endpoint has not been"
                     + " set. Session tracking is disabled");
-            this.autoCaptureSessions.set(false);
+            this.autoCaptureSessions = false;
         } else {
             sessionEndpoint = sessions;
         }

--- a/bugsnag/src/main/java/com/bugsnag/Configuration.java
+++ b/bugsnag/src/main/java/com/bugsnag/Configuration.java
@@ -187,7 +187,7 @@ public class Configuration {
 
     Map<String, String> getErrorApiHeaders() {
         Map<String, String> map = new HashMap<String, String>();
-        map.put(HEADER_API_PAYLOAD_VERSION, Report.PAYLOAD_VERSION);
+        map.put(HEADER_API_PAYLOAD_VERSION, Event.PAYLOAD_VERSION);
         map.put(HEADER_API_KEY, apiKey);
         map.put(HEADER_BUGSNAG_SENT_AT, DateUtils.toIso8601(new Date()));
         return map;

--- a/bugsnag/src/main/java/com/bugsnag/Configuration.java
+++ b/bugsnag/src/main/java/com/bugsnag/Configuration.java
@@ -1,7 +1,7 @@
 package com.bugsnag;
 
 import com.bugsnag.callbacks.AppCallback;
-import com.bugsnag.callbacks.Callback;
+import com.bugsnag.callbacks.OnErrorCallback;
 import com.bugsnag.callbacks.DeviceCallback;
 import com.bugsnag.callbacks.JakartaServletCallback;
 import com.bugsnag.delivery.AsyncHttpDelivery;
@@ -19,7 +19,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
@@ -37,7 +37,7 @@ public class Configuration {
     private Delivery delivery;
     private EndpointConfiguration endpoints;
     private Delivery sessionDelivery;
-    private String[] redactedKeys = new String[] {"password", "secret", "Authorization", "Cookie"};
+    private String[] redactedKeys = new String[]{"password", "secret", "Authorization", "Cookie"};
     private Set<Pattern> discardClassRegexPatterns = new HashSet<Pattern>();
     private Set<String> discardClassStringPatterns = new HashSet<String>();
     private Set<String> enabledReleaseStages = null;
@@ -46,7 +46,7 @@ public class Configuration {
     private ThreadSendPolicy sendThreads = ThreadSendPolicy.NEVER;
     private Serializer serializer = new DefaultSerializer();
 
-    Collection<Callback> callbacks = new ConcurrentLinkedQueue<Callback>();
+    Set<OnErrorCallback> callbacks = new CopyOnWriteArraySet<>();
     private final AtomicBoolean autoCaptureSessions = new AtomicBoolean(true);
     private final AtomicBoolean sendUncaughtExceptions = new AtomicBoolean(true);
     private final FeatureFlagStore featureFlagStore = new FeatureFlagStore();
@@ -54,8 +54,8 @@ public class Configuration {
     Configuration(String apiKey) {
         this.apiKey = apiKey;
         // Add built-in callbacks
-        addCallback(new AppCallback(this));
-        addCallback(new DeviceCallback());
+        addOnError(new AppCallback(this));
+        addOnError(new DeviceCallback());
         DeviceCallback.initializeCache();
 
         endpoints = EndpointConfiguration.fromApiKey(apiKey);
@@ -64,7 +64,7 @@ public class Configuration {
         this.sessionDelivery = new AsyncHttpDelivery(endpoints.getSessionEndpoint());
 
         if (JakartaServletCallback.isAvailable()) {
-            addCallback(new JakartaServletCallback());
+            addOnError(new JakartaServletCallback());
         }
     }
 
@@ -88,10 +88,8 @@ public class Configuration {
         return false;
     }
 
-    void addCallback(Callback callback) {
-        if (!callbacks.contains(callback)) {
-            callbacks.add(callback);
-        }
+    void addOnError(OnErrorCallback callback) {
+        callbacks.add(callback);
     }
 
     boolean inProject(String className) {
@@ -348,7 +346,7 @@ public class Configuration {
      * Add a feature flag with the specified name and variant.
      * If the name already exists, the variant will be updated.
      *
-     * @param name the feature flag name
+     * @param name    the feature flag name
      * @param variant the feature flag variant (can be null)
      */
     public void addFeatureFlag(String name, String variant) {

--- a/bugsnag/src/main/java/com/bugsnag/Configuration.java
+++ b/bugsnag/src/main/java/com/bugsnag/Configuration.java
@@ -43,7 +43,7 @@ public class Configuration {
     private Set<String> enabledReleaseStages = null;
     private String[] projectPackages;
     private String releaseStage;
-    private boolean sendThreads = false;
+    private ThreadSendPolicy sendThreads = ThreadSendPolicy.NEVER;
     private Serializer serializer = new DefaultSerializer();
 
     Collection<Callback> callbacks = new ConcurrentLinkedQueue<Callback>();
@@ -328,11 +328,11 @@ public class Configuration {
         this.releaseStage = releaseStage;
     }
 
-    public boolean isSendThreads() {
+    public ThreadSendPolicy getSendThreads() {
         return sendThreads;
     }
 
-    public void setSendThreads(boolean sendThreads) {
+    public void setSendThreads(ThreadSendPolicy sendThreads) {
         this.sendThreads = sendThreads;
     }
 

--- a/bugsnag/src/main/java/com/bugsnag/Configuration.java
+++ b/bugsnag/src/main/java/com/bugsnag/Configuration.java
@@ -1,9 +1,9 @@
 package com.bugsnag;
 
 import com.bugsnag.callbacks.AppCallback;
-import com.bugsnag.callbacks.OnErrorCallback;
 import com.bugsnag.callbacks.DeviceCallback;
 import com.bugsnag.callbacks.JakartaServletCallback;
+import com.bugsnag.callbacks.OnErrorCallback;
 import com.bugsnag.delivery.AsyncHttpDelivery;
 import com.bugsnag.delivery.Delivery;
 import com.bugsnag.delivery.HttpDelivery;

--- a/bugsnag/src/main/java/com/bugsnag/Configuration.java
+++ b/bugsnag/src/main/java/com/bugsnag/Configuration.java
@@ -187,7 +187,7 @@ public class Configuration {
 
     Map<String, String> getErrorApiHeaders() {
         Map<String, String> map = new HashMap<String, String>();
-        map.put(HEADER_API_PAYLOAD_VERSION, Event.PAYLOAD_VERSION);
+        map.put(HEADER_API_PAYLOAD_VERSION, BugsnagEvent.PAYLOAD_VERSION);
         map.put(HEADER_API_KEY, apiKey);
         map.put(HEADER_BUGSNAG_SENT_AT, DateUtils.toIso8601(new Date()));
         return map;

--- a/bugsnag/src/main/java/com/bugsnag/Error.java
+++ b/bugsnag/src/main/java/com/bugsnag/Error.java
@@ -4,12 +4,12 @@ import com.bugsnag.serialization.Expose;
 
 import java.util.List;
 
-class Exception {
+public class Error {
     private Configuration config;
     private Throwable throwable;
     private String errorClass;
 
-    Exception(Configuration config, Throwable throwable) {
+    Error(Configuration config, Throwable throwable) {
         this.config = config;
         this.throwable = throwable;
         this.errorClass = throwable.getClass().getName();

--- a/bugsnag/src/main/java/com/bugsnag/Event.java
+++ b/bugsnag/src/main/java/com/bugsnag/Event.java
@@ -18,7 +18,7 @@ public class Event {
     private Configuration config;
 
     private String apiKey;
-    private final Exception exception;
+    private final Error error;
     private HandledState handledState;
     private Severity severity;
     private String groupingHash;
@@ -47,7 +47,7 @@ public class Event {
     Event(Configuration config, Throwable throwable,
           HandledState handledState, Thread currentThread, FeatureFlagStore clientFeatureFlagStore) {
         this.config = config;
-        this.exception = new Exception(config, throwable);
+        this.error = new Error(config, throwable);
         this.handledState = handledState;
         this.severity = handledState.getOriginalSeverity();
         diagnostics = new Diagnostics(this.config);
@@ -78,17 +78,17 @@ public class Event {
      * @return the exceptions that make up the error.
      */
     @Expose
-    protected List<Exception> getExceptions() {
-        List<Exception> exceptions = new ArrayList<Exception>();
-        exceptions.add(exception);
+    protected List<Error> getErrors() {
+        List<Error> errors = new ArrayList<Error>();
+        errors.add(error);
 
-        Throwable currentThrowable = exception.getThrowable().getCause();
+        Throwable currentThrowable = error.getThrowable().getCause();
         while (currentThrowable != null) {
-            exceptions.add(new Exception(config, currentThrowable));
+            errors.add(new Error(config, currentThrowable));
             currentThrowable = currentThrowable.getCause();
         }
 
-        return exceptions;
+        return errors;
     }
 
     @Expose
@@ -168,14 +168,14 @@ public class Event {
      *         report.
      */
     public Throwable getException() {
-        return exception.getThrowable();
+        return error.getThrowable();
     }
 
     /**
      * @return the class name from the exception contained in this error report.
      */
     public String getExceptionName() {
-        return exception.getErrorClass();
+        return error.getErrorClass();
     }
 
     /**
@@ -184,14 +184,14 @@ public class Event {
      * @param exceptionName the error name
      */
     public void setExceptionName(String exceptionName) {
-        exception.setErrorClass(exceptionName);
+        error.setErrorClass(exceptionName);
     }
 
     /**
      * @return The message from the exception contained in this error report.
      */
     public String getExceptionMessage() {
-        return exception.getThrowable().getLocalizedMessage();
+        return error.getThrowable().getLocalizedMessage();
     }
 
     /**

--- a/bugsnag/src/main/java/com/bugsnag/Event.java
+++ b/bugsnag/src/main/java/com/bugsnag/Event.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class Report {
+public class Event {
 
     static final String PAYLOAD_VERSION = "4";
 
@@ -34,18 +34,18 @@ public class Report {
      * @param config    the configuration for the report.
      * @param throwable the error to create the report for.
      */
-    protected Report(Configuration config, Throwable throwable) {
+    protected Event(Configuration config, Throwable throwable) {
         this(config, throwable, HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_HANDLED_EXCEPTION), Thread.currentThread(), null);
     }
 
-    Report(Configuration config, Throwable throwable,
-            HandledState handledState, Thread currentThread) {
+    Event(Configuration config, Throwable throwable,
+          HandledState handledState, Thread currentThread) {
         this(config, throwable, handledState, currentThread, null);
     }
 
-    Report(Configuration config, Throwable throwable,
-            HandledState handledState, Thread currentThread, FeatureFlagStore clientFeatureFlagStore) {
+    Event(Configuration config, Throwable throwable,
+          HandledState handledState, Thread currentThread, FeatureFlagStore clientFeatureFlagStore) {
         this.config = config;
         this.exception = new Exception(config, throwable);
         this.handledState = handledState;
@@ -202,7 +202,7 @@ public class Report {
      * @param value   the metadata value to add
      * @return the modified report
      */
-    public Report addMetadata(String tabName, String key, Object value) {
+    public Event addMetadata(String tabName, String key, Object value) {
         diagnostics.metadata.addMetadata(tabName, key, value);
         return this;
     }
@@ -213,7 +213,7 @@ public class Report {
      * @param tabName the name of the tab to clear.
      * @return The message from the exception contained in this error report.
      */
-    public Report clearTab(String tabName) {
+    public Event clearTab(String tabName) {
         diagnostics.metadata.clearMetadata(tabName);
         return this;
     }
@@ -227,7 +227,7 @@ public class Report {
      * @deprecated use {@link #addMetadata(String, String, Object)} instead
      */
     @Deprecated
-    public Report setAppInfo(String key, Object value) {
+    public Event setAppInfo(String key, Object value) {
         diagnostics.app.put(key, value);
         return this;
     }
@@ -238,7 +238,7 @@ public class Report {
      * @param apiKey the API key to use in the report
      * @return the modified report
      */
-    public Report setApiKey(String apiKey) {
+    public Event setApiKey(String apiKey) {
         this.apiKey = apiKey;
         return this;
     }
@@ -258,7 +258,7 @@ public class Report {
      * @param context the context to use in the report
      * @return the modified report
      */
-    public Report setContext(String context) {
+    public Event setContext(String context) {
         diagnostics.context = context;
         return this;
     }
@@ -272,7 +272,7 @@ public class Report {
      * @deprecated use {@link #addMetadata(String, String, Object)} instead
      */
     @Deprecated
-    public Report setDeviceInfo(String key, Object value) {
+    public Event setDeviceInfo(String key, Object value) {
         diagnostics.device.put(key, value);
         return this;
     }
@@ -285,7 +285,7 @@ public class Report {
      * @param groupingHash the grouping hash for the error report
      * @return the modified report
      */
-    public Report setGroupingHash(String groupingHash) {
+    public Event setGroupingHash(String groupingHash) {
         this.groupingHash = groupingHash;
         return this;
     }
@@ -296,7 +296,7 @@ public class Report {
      * @param severity the severity for the error report
      * @return the modified report
      */
-    public Report setSeverity(Severity severity) {
+    public Event setSeverity(Severity severity) {
         this.severity = severity;
         this.handledState.setCurrentSeverity(severity);
         return this;
@@ -310,29 +310,29 @@ public class Report {
      * @param name  the name of the user.
      * @return the modified report.
      */
-    public Report setUser(String id, String email, String name) {
+    public Event setUser(String id, String email, String name) {
         diagnostics.user.put("id", id);
         diagnostics.user.put("email", email);
         diagnostics.user.put("name", name);
         return this;
     }
 
-    public Report setUserId(String id) {
+    public Event setUserId(String id) {
         diagnostics.user.put("id", id);
         return this;
     }
 
-    public Report setUserEmail(String email) {
+    public Event setUserEmail(String email) {
         diagnostics.user.put("email", email);
         return this;
     }
 
-    public Report setUserName(String name) {
+    public Event setUserName(String name) {
         diagnostics.user.put("name", name);
         return this;
     }
 
-    public Report cancel() {
+    public Event cancel() {
         this.shouldCancel = true;
         return this;
     }
@@ -372,7 +372,7 @@ public class Report {
      * @param variant the feature flag variant (can be null)
      * @return the modified report
      */
-    public Report addFeatureFlag(String name, String variant) {
+    public Event addFeatureFlag(String name, String variant) {
         featureFlagStore.addFeatureFlag(name, variant);
         return this;
     }
@@ -383,7 +383,7 @@ public class Report {
      * @param name the feature flag name
      * @return the modified report
      */
-    public Report addFeatureFlag(String name) {
+    public Event addFeatureFlag(String name) {
         return addFeatureFlag(name, null);
     }
 
@@ -394,7 +394,7 @@ public class Report {
      * @param featureFlags the feature flags to add
      * @return the modified report
      */
-    public Report addFeatureFlags(Collection<FeatureFlag> featureFlags) {
+    public Event addFeatureFlags(Collection<FeatureFlag> featureFlags) {
         featureFlagStore.addFeatureFlags(featureFlags);
         return this;
     }
@@ -405,7 +405,7 @@ public class Report {
      * @param name the feature flag name to remove
      * @return the modified report
      */
-    public Report clearFeatureFlag(String name) {
+    public Event clearFeatureFlag(String name) {
         featureFlagStore.clearFeatureFlag(name);
         return this;
     }
@@ -415,7 +415,7 @@ public class Report {
      *
      * @return the modified report
      */
-    public Report clearFeatureFlags() {
+    public Event clearFeatureFlags() {
         featureFlagStore.clearFeatureFlags();
         return this;
     }

--- a/bugsnag/src/main/java/com/bugsnag/ExceptionHandler.java
+++ b/bugsnag/src/main/java/com/bugsnag/ExceptionHandler.java
@@ -49,7 +49,7 @@ class ExceptionHandler implements UncaughtExceptionHandler {
     }
 
     @Override
-    public void uncaughtException(Thread thread, Throwable throwable) {
+    public void uncaughtException(java.lang.Thread thread, Throwable throwable) {
         // Notify any subscribed clients of the uncaught exception
         for (Bugsnag bugsnag : clientMap.keySet()) {
             if (bugsnag.getConfig().shouldSendUncaughtExceptions()) {

--- a/bugsnag/src/main/java/com/bugsnag/Notification.java
+++ b/bugsnag/src/main/java/com/bugsnag/Notification.java
@@ -7,9 +7,9 @@ import java.util.List;
 
 class Notification {
     private Configuration config;
-    private Event event;
+    private BugsnagEvent event;
 
-    Notification(Configuration config, Event event) {
+    Notification(Configuration config, BugsnagEvent event) {
         this.config = config;
         this.event = event;
     }
@@ -26,7 +26,7 @@ class Notification {
     }
 
     @Expose
-    public List<Event> getEvents() {
+    public List<BugsnagEvent> getEvents() {
         return Collections.singletonList(event);
     }
 }

--- a/bugsnag/src/main/java/com/bugsnag/Notification.java
+++ b/bugsnag/src/main/java/com/bugsnag/Notification.java
@@ -7,16 +7,16 @@ import java.util.List;
 
 class Notification {
     private Configuration config;
-    private Report report;
+    private Event event;
 
-    Notification(Configuration config, Report report) {
+    Notification(Configuration config, Event event) {
         this.config = config;
-        this.report = report;
+        this.event = event;
     }
 
     @Expose
     public String getApiKey() {
-        String reportApiKey = report.getApiKey();
+        String reportApiKey = event.getApiKey();
         return reportApiKey != null ? reportApiKey : config.getApiKey();
     }
 
@@ -26,7 +26,7 @@ class Notification {
     }
 
     @Expose
-    public List<Report> getEvents() {
-        return Collections.singletonList(report);
+    public List<Event> getEvents() {
+        return Collections.singletonList(event);
     }
 }

--- a/bugsnag/src/main/java/com/bugsnag/Stackframe.java
+++ b/bugsnag/src/main/java/com/bugsnag/Stackframe.java
@@ -5,7 +5,7 @@ import com.bugsnag.serialization.Expose;
 import java.util.ArrayList;
 import java.util.List;
 
-class Stackframe {
+public class Stackframe {
     private Configuration config;
     private StackTraceElement el;
 

--- a/bugsnag/src/main/java/com/bugsnag/ThreadSendPolicy.java
+++ b/bugsnag/src/main/java/com/bugsnag/ThreadSendPolicy.java
@@ -1,0 +1,22 @@
+package com.bugsnag;
+
+/**
+ * Controls whether we should capture and serialize the state of all threads at the time of an error.
+ */
+public enum ThreadSendPolicy {
+    /**
+     * Threads should be captured for all events. This is often not useful for Java web apps, since
+     * there could be thousands of active threads depending on your environment.
+     */
+    ALWAYS,
+
+    /**
+     * Threads should be captured for unhandled events only.
+     */
+    UNHANDLED_ONLY,
+
+    /**
+     * Threads should never be captured.
+     */
+    NEVER
+}

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/AppCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/AppCallback.java
@@ -3,7 +3,7 @@ package com.bugsnag.callbacks;
 import com.bugsnag.Configuration;
 import com.bugsnag.BugsnagEvent;
 
-public class AppCallback implements Callback {
+public class AppCallback implements OnErrorCallback {
     private Configuration config;
 
     public AppCallback(Configuration config) {

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/AppCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/AppCallback.java
@@ -1,7 +1,7 @@
 package com.bugsnag.callbacks;
 
 import com.bugsnag.Configuration;
-import com.bugsnag.Report;
+import com.bugsnag.Event;
 
 public class AppCallback implements Callback {
     private Configuration config;
@@ -11,17 +11,17 @@ public class AppCallback implements Callback {
     }
 
     @Override
-    public boolean onError(Report report) {
+    public boolean onError(Event event) {
         if (config.getAppType() != null) {
-            report.setAppInfo("type", config.getAppType());
+            event.setAppInfo("type", config.getAppType());
         }
 
         if (config.getAppVersion() != null) {
-            report.setAppInfo("version", config.getAppVersion());
+            event.setAppInfo("version", config.getAppVersion());
         }
 
         if (config.getReleaseStage() != null) {
-            report.setAppInfo("releaseStage", config.getReleaseStage());
+            event.setAppInfo("releaseStage", config.getReleaseStage());
         }
         return true;
     }

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/AppCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/AppCallback.java
@@ -1,7 +1,7 @@
 package com.bugsnag.callbacks;
 
 import com.bugsnag.Configuration;
-import com.bugsnag.Event;
+import com.bugsnag.BugsnagEvent;
 
 public class AppCallback implements Callback {
     private Configuration config;
@@ -11,7 +11,7 @@ public class AppCallback implements Callback {
     }
 
     @Override
-    public boolean onError(Event event) {
+    public boolean onError(BugsnagEvent event) {
         if (config.getAppType() != null) {
             event.setAppInfo("type", config.getAppType());
         }

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/AppCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/AppCallback.java
@@ -1,7 +1,7 @@
 package com.bugsnag.callbacks;
 
-import com.bugsnag.Configuration;
 import com.bugsnag.BugsnagEvent;
+import com.bugsnag.Configuration;
 
 public class AppCallback implements OnErrorCallback {
     private Configuration config;

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/Callback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/Callback.java
@@ -1,6 +1,6 @@
 package com.bugsnag.callbacks;
 
-import com.bugsnag.Event;
+import com.bugsnag.BugsnagEvent;
 
 public interface Callback {
     /**
@@ -12,5 +12,5 @@ public interface Callback {
      * @param event the report to perform changes on.
      * @return true to send, false to suppress delivery
      */
-    boolean onError(Event event);
+    boolean onError(BugsnagEvent event);
 }

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/Callback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/Callback.java
@@ -1,6 +1,6 @@
 package com.bugsnag.callbacks;
 
-import com.bugsnag.Report;
+import com.bugsnag.Event;
 
 public interface Callback {
     /**
@@ -9,8 +9,8 @@ public interface Callback {
      * Implementations may also call {@code report.cancel()} for backward
      * compatibility.
      *
-     * @param report the report to perform changes on.
+     * @param event the report to perform changes on.
      * @return true to send, false to suppress delivery
      */
-    boolean onError(Report report);
+    boolean onError(Event event);
 }

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
@@ -1,6 +1,6 @@
 package com.bugsnag.callbacks;
 
-import com.bugsnag.Report;
+import com.bugsnag.Event;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -84,8 +84,8 @@ public class DeviceCallback implements Callback {
     }
 
     @Override
-    public boolean onError(Report report) {
-        report
+    public boolean onError(Event event) {
+        event
                 .addMetadata("device", "osArch", System.getProperty("os.arch"))
                 .addMetadata("device", "locale", Locale.getDefault())
                 .setDeviceInfo("hostname", getHostnameValue())

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
@@ -1,6 +1,6 @@
 package com.bugsnag.callbacks;
 
-import com.bugsnag.Event;
+import com.bugsnag.BugsnagEvent;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -84,7 +84,7 @@ public class DeviceCallback implements Callback {
     }
 
     @Override
-    public boolean onError(Event event) {
+    public boolean onError(BugsnagEvent event) {
         event
                 .addMetadata("device", "osArch", System.getProperty("os.arch"))
                 .addMetadata("device", "locale", Locale.getDefault())

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/DeviceCallback.java
@@ -11,7 +11,7 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-public class DeviceCallback implements Callback {
+public class DeviceCallback implements OnErrorCallback {
 
     private static volatile String hostname;
     private static volatile boolean hostnameInitialised;

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/JakartaServletCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/JakartaServletCallback.java
@@ -9,7 +9,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 
-public class JakartaServletCallback implements Callback {
+public class JakartaServletCallback implements OnErrorCallback {
     private static final String HEADER_X_FORWARDED_FOR = "X-FORWARDED-FOR";
 
     /**

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/JakartaServletCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/JakartaServletCallback.java
@@ -1,6 +1,6 @@
 package com.bugsnag.callbacks;
 
-import com.bugsnag.Report;
+import com.bugsnag.Event;
 import com.bugsnag.servlet.jakarta.BugsnagServletRequestListener;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,7 +26,7 @@ public class JakartaServletCallback implements Callback {
     }
 
     @Override
-    public boolean onError(Report report) {
+    public boolean onError(Event event) {
         // Check if we have any servlet request data available
         HttpServletRequest request = BugsnagServletRequestListener.getServletRequest();
         if (request == null) {
@@ -34,7 +34,7 @@ public class JakartaServletCallback implements Callback {
         }
 
         // Add request information to metadata
-        report
+        event
                 .addMetadata("request", "url", request.getRequestURL().toString())
                 .addMetadata("request", "method", request.getMethod())
                 .addMetadata("request", "params",
@@ -43,8 +43,8 @@ public class JakartaServletCallback implements Callback {
                 .addMetadata("request", "headers", getHeaderMap(request));
 
         // Set default context
-        if (report.getContext() == null) {
-            report.setContext(request.getMethod() + " " + request.getRequestURI());
+        if (event.getContext() == null) {
+            event.setContext(request.getMethod() + " " + request.getRequestURI());
         }
         return true;
     }

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/JakartaServletCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/JakartaServletCallback.java
@@ -1,6 +1,6 @@
 package com.bugsnag.callbacks;
 
-import com.bugsnag.Event;
+import com.bugsnag.BugsnagEvent;
 import com.bugsnag.servlet.jakarta.BugsnagServletRequestListener;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,7 +26,7 @@ public class JakartaServletCallback implements Callback {
     }
 
     @Override
-    public boolean onError(Event event) {
+    public boolean onError(BugsnagEvent event) {
         // Check if we have any servlet request data available
         HttpServletRequest request = BugsnagServletRequestListener.getServletRequest();
         if (request == null) {

--- a/bugsnag/src/main/java/com/bugsnag/callbacks/OnErrorCallback.java
+++ b/bugsnag/src/main/java/com/bugsnag/callbacks/OnErrorCallback.java
@@ -2,12 +2,10 @@ package com.bugsnag.callbacks;
 
 import com.bugsnag.BugsnagEvent;
 
-public interface Callback {
+public interface OnErrorCallback {
     /**
      * Perform changes to the report before delivery.
      * Return {@code true} to continue sending, or {@code false} to cancel delivery.
-     * Implementations may also call {@code report.cancel()} for backward
-     * compatibility.
      *
      * @param event the report to perform changes on.
      * @return true to send, false to suppress delivery

--- a/bugsnag/src/main/java/com/bugsnag/logback/BugsnagMarker.java
+++ b/bugsnag/src/main/java/com/bugsnag/logback/BugsnagMarker.java
@@ -1,6 +1,6 @@
 package com.bugsnag.logback;
 
-import com.bugsnag.callbacks.Callback;
+import com.bugsnag.callbacks.OnErrorCallback;
 
 import org.slf4j.Marker;
 
@@ -17,15 +17,15 @@ public class BugsnagMarker implements Marker {
 
     private static final String BUGSNAG_MARKER_NAME = "BUGSNAG_MARKER";
 
-    private Callback callback;
+    private OnErrorCallback callback;
 
     private List<Marker> references = new ArrayList<Marker>();
 
-    public BugsnagMarker(Callback callback) {
+    public BugsnagMarker(OnErrorCallback callback) {
         this.callback = callback;
     }
 
-    public Callback getCallback() {
+    public OnErrorCallback getCallback() {
         return callback;
     }
 

--- a/bugsnag/src/test/java/com/bugsnag/AppenderMetadataTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderMetadataTest.java
@@ -123,7 +123,7 @@ public class AppenderMetadataTest {
         // Check the metadata is set as expected
         // Should have both report and thread metadata
         Notification notification = delivery.getNotifications().get(0);
-        Event event = notification.getEvents().get(0);
+        BugsnagEvent event = notification.getEvents().get(0);
 
         assertTrue(event.getMetadata().containsKey("report"));
         assertTrue(event.getMetadata().containsKey("thread"));

--- a/bugsnag/src/test/java/com/bugsnag/AppenderMetadataTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderMetadataTest.java
@@ -123,25 +123,25 @@ public class AppenderMetadataTest {
         // Check the metadata is set as expected
         // Should have both report and thread metadata
         Notification notification = delivery.getNotifications().get(0);
-        Report report = notification.getEvents().get(0);
+        Event event = notification.getEvents().get(0);
 
-        assertTrue(report.getMetadata().containsKey("report"));
-        assertTrue(report.getMetadata().containsKey("thread"));
+        assertTrue(event.getMetadata().containsKey("report"));
+        assertTrue(event.getMetadata().containsKey("thread"));
         assertEquals("some report value", getMetadataMap(notification, "report").get("some key"));
         assertEquals("some thread value", getMetadataMap(notification, "thread").get("some key"));
 
         // Should have just thread metadata
         notification = delivery.getNotifications().get(1);
-        report = notification.getEvents().get(0);
-        assertFalse(report.getMetadata().containsKey("report"));
-        assertTrue(report.getMetadata().containsKey("thread"));
+        event = notification.getEvents().get(0);
+        assertFalse(event.getMetadata().containsKey("report"));
+        assertTrue(event.getMetadata().containsKey("thread"));
         assertEquals("some thread value", getMetadataMap(notification, "thread").get("some key"));
 
         // Should have neither metadata
         notification = delivery.getNotifications().get(2);
-        report = notification.getEvents().get(0);
-        assertFalse(report.getMetadata().containsKey("report"));
-        assertFalse(report.getMetadata().containsKey("thread"));
+        event = notification.getEvents().get(0);
+        assertFalse(event.getMetadata().containsKey("report"));
+        assertFalse(event.getMetadata().containsKey("thread"));
     }
 
     @Test

--- a/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
@@ -247,9 +247,9 @@ public class AppenderTest {
         // Check that a report was sent to Bugsnag
         assertEquals(1, delivery.getNotifications().size());
         Notification notification = delivery.getNotifications().get(0);
-        Report report = notification.getEvents().get(0);
+        Event event = notification.getEvents().get(0);
 
-        List<Stackframe> frames = report.getExceptions().get(0).getStacktrace();
+        List<Stackframe> frames = event.getExceptions().get(0).getStacktrace();
         assertTrue(frames.get(0).isInProject());
         assertTrue(frames.get(1).isInProject());
         for (int i = 2; i < frames.size(); i++) {

--- a/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
@@ -247,7 +247,7 @@ public class AppenderTest {
         // Check that a report was sent to Bugsnag
         assertEquals(1, delivery.getNotifications().size());
         Notification notification = delivery.getNotifications().get(0);
-        Event event = notification.getEvents().get(0);
+        BugsnagEvent event = notification.getEvents().get(0);
 
         List<Stackframe> frames = event.getErrors().get(0).getStacktrace();
         assertTrue(frames.get(0).isInProject());

--- a/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
@@ -249,7 +249,7 @@ public class AppenderTest {
         Notification notification = delivery.getNotifications().get(0);
         Event event = notification.getEvents().get(0);
 
-        List<Stackframe> frames = event.getExceptions().get(0).getStacktrace();
+        List<Stackframe> frames = event.getErrors().get(0).getStacktrace();
         assertTrue(frames.get(0).isInProject());
         assertTrue(frames.get(1).isInProject());
         for (int i = 2; i < frames.size(); i++) {

--- a/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/AppenderTest.java
@@ -138,7 +138,6 @@ public class AppenderTest {
 
     @Test
     public void testBugsnagConfig() {
-
         // Get the Bugsnag instance
         Configuration config = getConfig(appender.getClient());
         assertEquals("test", config.getReleaseStage());
@@ -175,7 +174,7 @@ public class AppenderTest {
         assertTrue(projectPackages.contains("com.company.package2"));
         assertTrue(projectPackages.contains("com.company.package1"));
 
-        assertTrue(config.isSendThreads());
+        assertEquals(ThreadSendPolicy.ALWAYS, config.getSendThreads());
     }
 
     @Test

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagFeatureFlagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagFeatureFlagTest.java
@@ -30,7 +30,7 @@ public class BugsnagFeatureFlagTest {
     public void testAddFeatureFlag() {
         bugsnag.addFeatureFlag("flag1", "variant-a");
 
-        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = bugsnag.buildReport(new RuntimeException("Test"));
         List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
@@ -42,7 +42,7 @@ public class BugsnagFeatureFlagTest {
     public void testAddFeatureFlagWithoutVariant() {
         bugsnag.addFeatureFlag("flag1");
 
-        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = bugsnag.buildReport(new RuntimeException("Test"));
         List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
@@ -58,7 +58,7 @@ public class BugsnagFeatureFlagTest {
 
         bugsnag.addFeatureFlags(flagsToAdd);
 
-        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = bugsnag.buildReport(new RuntimeException("Test"));
         List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(2, flags.size());
@@ -72,7 +72,7 @@ public class BugsnagFeatureFlagTest {
         bugsnag.addFeatureFlag("flag2", "variant-b");
         bugsnag.clearFeatureFlag("flag1");
 
-        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = bugsnag.buildReport(new RuntimeException("Test"));
         List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
@@ -85,7 +85,7 @@ public class BugsnagFeatureFlagTest {
         bugsnag.addFeatureFlag("flag2", "variant-b");
         bugsnag.clearFeatureFlags();
 
-        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = bugsnag.buildReport(new RuntimeException("Test"));
         List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(0, flags.size());
@@ -99,7 +99,7 @@ public class BugsnagFeatureFlagTest {
         Bugsnag client = new Bugsnag("api-key", false);
         client.getConfig().addFeatureFlag("config-flag", "config-variant");
 
-        Event event = client.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = client.buildReport(new RuntimeException("Test"));
         List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
@@ -118,7 +118,7 @@ public class BugsnagFeatureFlagTest {
         client.getConfig().addFeatureFlag("flag1", "config-variant");
         client.addFeatureFlag("flag1", "client-variant");
 
-        Event event = client.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = client.buildReport(new RuntimeException("Test"));
         List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
@@ -139,7 +139,7 @@ public class BugsnagFeatureFlagTest {
         client.getConfig().addFeatureFlag("flag2", "config-variant");
         client.addFeatureFlag("flag3", "client-variant");
 
-        Event event = client.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = client.buildReport(new RuntimeException("Test"));
         List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(3, flags.size());

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagFeatureFlagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagFeatureFlagTest.java
@@ -30,8 +30,8 @@ public class BugsnagFeatureFlagTest {
     public void testAddFeatureFlag() {
         bugsnag.addFeatureFlag("flag1", "variant-a");
 
-        Report report = bugsnag.buildReport(new RuntimeException("Test"));
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
         assertEquals("flag1", flags.get(0).getName());
@@ -42,8 +42,8 @@ public class BugsnagFeatureFlagTest {
     public void testAddFeatureFlagWithoutVariant() {
         bugsnag.addFeatureFlag("flag1");
 
-        Report report = bugsnag.buildReport(new RuntimeException("Test"));
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
         assertEquals("flag1", flags.get(0).getName());
@@ -58,8 +58,8 @@ public class BugsnagFeatureFlagTest {
 
         bugsnag.addFeatureFlags(flagsToAdd);
 
-        Report report = bugsnag.buildReport(new RuntimeException("Test"));
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(2, flags.size());
         assertEquals("flag1", flags.get(0).getName());
@@ -72,8 +72,8 @@ public class BugsnagFeatureFlagTest {
         bugsnag.addFeatureFlag("flag2", "variant-b");
         bugsnag.clearFeatureFlag("flag1");
 
-        Report report = bugsnag.buildReport(new RuntimeException("Test"));
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
         assertEquals("flag2", flags.get(0).getName());
@@ -85,8 +85,8 @@ public class BugsnagFeatureFlagTest {
         bugsnag.addFeatureFlag("flag2", "variant-b");
         bugsnag.clearFeatureFlags();
 
-        Report report = bugsnag.buildReport(new RuntimeException("Test"));
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(0, flags.size());
     }
@@ -99,8 +99,8 @@ public class BugsnagFeatureFlagTest {
         Bugsnag client = new Bugsnag("api-key", false);
         client.getConfig().addFeatureFlag("config-flag", "config-variant");
 
-        Report report = client.buildReport(new RuntimeException("Test"));
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        Event event = client.buildReport(new RuntimeException("Test"));
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
         assertEquals("config-flag", flags.get(0).getName());
@@ -118,8 +118,8 @@ public class BugsnagFeatureFlagTest {
         client.getConfig().addFeatureFlag("flag1", "config-variant");
         client.addFeatureFlag("flag1", "client-variant");
 
-        Report report = client.buildReport(new RuntimeException("Test"));
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        Event event = client.buildReport(new RuntimeException("Test"));
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
         assertEquals("flag1", flags.get(0).getName());
@@ -139,8 +139,8 @@ public class BugsnagFeatureFlagTest {
         client.getConfig().addFeatureFlag("flag2", "config-variant");
         client.addFeatureFlag("flag3", "client-variant");
 
-        Report report = client.buildReport(new RuntimeException("Test"));
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        Event event = client.buildReport(new RuntimeException("Test"));
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(3, flags.size());
         assertEquals("flag1", flags.get(0).getName());

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
@@ -257,7 +257,7 @@ public class BugsnagTest {
 
     @Test
     public void testContext() {
-        bugsnag.addCallback(report -> {
+        bugsnag.addOnError(report -> {
             report.setContext("the context");
             return true;
         });
@@ -277,7 +277,7 @@ public class BugsnagTest {
 
     @Test
     public void testGroupingHash() {
-        bugsnag.addCallback(report -> {
+        bugsnag.addOnError(report -> {
             report.setGroupingHash("the grouping hash");
             return true;
         });
@@ -297,7 +297,7 @@ public class BugsnagTest {
 
     @Test
     public void testSingleCallback() {
-        bugsnag.addCallback(report -> {
+        bugsnag.addOnError(report -> {
             report.setApiKey("newapikey");
             return true;
         });
@@ -337,11 +337,11 @@ public class BugsnagTest {
 
     @Test
     public void testCallbackOrder() {
-        bugsnag.addCallback(report -> {
+        bugsnag.addOnError(report -> {
             report.setApiKey("newapikey");
             return true;
         });
-        bugsnag.addCallback(report -> {
+        bugsnag.addOnError(report -> {
             report.setApiKey("secondnewapikey");
             return true;
         });
@@ -357,17 +357,6 @@ public class BugsnagTest {
             }
         });
         assertTrue(bugsnag.notify(new Throwable()));
-    }
-
-    @Test
-    public void testCallbackCancel() {
-        bugsnag.setDelivery(BugsnagTestUtils.generateDelivery());
-        bugsnag.addCallback(report -> {
-            report.cancel();
-            return true; // cancellation flag respected
-        });
-        // Test the report is not sent
-        assertFalse(bugsnag.notify(new Throwable()));
     }
 
     @SuppressWarnings("deprecation") // ensures deprecated setEndpoint method still works correctly

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
@@ -438,13 +438,13 @@ public class BugsnagTest {
 
     @Test
     public void testSendThreads() {
-        bugsnag.setSendThreads(true);
+        bugsnag.setSendThreads(ThreadSendPolicy.ALWAYS);
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
                 BugsnagEvent event = ((Notification) object).getEvents().get(0);
                 // There is information about at least one thread
-                assertTrue(event.getThreads().size() > 0);
+                assertFalse(event.getThreads().isEmpty());
             }
 
             @Override

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
@@ -104,7 +104,7 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Event event = ((Notification) object).getEvents().get(0);
+                BugsnagEvent event = ((Notification) object).getEvents().get(0);
                 assertTrue(event.getErrors().get(0).getStacktrace().get(0).isInProject());
             }
 
@@ -123,7 +123,7 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Event event = ((Notification) object).getEvents().get(0);
+                BugsnagEvent event = ((Notification) object).getEvents().get(0);
                 assertEquals("1.2.3", event.getApp().get("version"));
             }
 
@@ -140,7 +140,7 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Event event = ((Notification) object).getEvents().get(0);
+                BugsnagEvent event = ((Notification) object).getEvents().get(0);
                 assertEquals("testtype", event.getApp().get("type"));
             }
 
@@ -156,7 +156,7 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Event event = ((Notification) object).getEvents().get(0);
+                BugsnagEvent event = ((Notification) object).getEvents().get(0);
                 assertEquals(Severity.INFO.getValue(), event.getSeverity());
             }
 
@@ -174,7 +174,7 @@ public class BugsnagTest {
             @SuppressWarnings("unchecked")
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Event event = ((Notification) object).getEvents().get(0);
+                BugsnagEvent event = ((Notification) object).getEvents().get(0);
                 Map<String, Object> firstTab =
                         (Map<String, Object>) event.getMetadata().get("firsttab");
                 final Map<String, Object> secondTab =
@@ -204,7 +204,7 @@ public class BugsnagTest {
             @SuppressWarnings("unchecked")
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Event event = ((Notification) object).getEvents().get(0);
+                BugsnagEvent event = ((Notification) object).getEvents().get(0);
                 Map<String, Object> requestTab =
                         (Map<String, Object>) event.getMetadata().get("request");
 
@@ -239,7 +239,7 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Event event = ((Notification) object).getEvents().get(0);
+                BugsnagEvent event = ((Notification) object).getEvents().get(0);
                 assertEquals("123", event.getUser().get("id"));
                 assertEquals("test@example.com", event.getUser().get("email"));
                 assertEquals("test name", event.getUser().get("name"));
@@ -264,7 +264,7 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Event event = ((Notification) object).getEvents().get(0);
+                BugsnagEvent event = ((Notification) object).getEvents().get(0);
                 assertEquals("the context", event.getContext());
             }
 
@@ -284,7 +284,7 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Event event = ((Notification) object).getEvents().get(0);
+                BugsnagEvent event = ((Notification) object).getEvents().get(0);
                 assertEquals("the grouping hash", event.getGroupingHash());
             }
 
@@ -304,7 +304,7 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Event event = ((Notification) object).getEvents().get(0);
+                BugsnagEvent event = ((Notification) object).getEvents().get(0);
                 assertEquals("newapikey", event.getApiKey());
             }
 
@@ -320,7 +320,7 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Event event = ((Notification) object).getEvents().get(0);
+                BugsnagEvent event = ((Notification) object).getEvents().get(0);
                 assertEquals("newapikey", event.getApiKey());
             }
 
@@ -348,7 +348,7 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Event event = ((Notification) object).getEvents().get(0);
+                BugsnagEvent event = ((Notification) object).getEvents().get(0);
                 assertEquals("secondnewapikey", event.getApiKey());
             }
 
@@ -442,7 +442,7 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Event event = ((Notification) object).getEvents().get(0);
+                BugsnagEvent event = ((Notification) object).getEvents().get(0);
                 // There is information about at least one thread
                 assertTrue(event.getThreads().size() > 0);
             }
@@ -459,7 +459,7 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Event event = ((Notification) object).getEvents().get(0);
+                BugsnagEvent event = ((Notification) object).getEvents().get(0);
                 assertNull(event.getSession());
             }
 
@@ -476,7 +476,7 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Event event = ((Notification) object).getEvents().get(0);
+                BugsnagEvent event = ((Notification) object).getEvents().get(0);
 
                 Map<String, Object> session = event.getSession();
                 assertNotNull(session);
@@ -505,7 +505,7 @@ public class BugsnagTest {
         assertTrue(bugsnag.notify(new Throwable()));
 
         for (int i = 0; i < testDelivery.getNotifications().size(); i++) {
-            Event event = testDelivery.getNotifications().get(i).getEvents().get(0);
+            BugsnagEvent event = testDelivery.getNotifications().get(i).getEvents().get(0);
 
             Map<String, Object> session = event.getSession();
             assertNotNull(session);

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
@@ -105,7 +105,7 @@ public class BugsnagTest {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
                 Event event = ((Notification) object).getEvents().get(0);
-                assertTrue(event.getExceptions().get(0).getStacktrace().get(0).isInProject());
+                assertTrue(event.getErrors().get(0).getStacktrace().get(0).isInProject());
             }
 
             @Override

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagTest.java
@@ -104,8 +104,8 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Report report = ((Notification) object).getEvents().get(0);
-                assertTrue(report.getExceptions().get(0).getStacktrace().get(0).isInProject());
+                Event event = ((Notification) object).getEvents().get(0);
+                assertTrue(event.getExceptions().get(0).getStacktrace().get(0).isInProject());
             }
 
             @Override
@@ -123,8 +123,8 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Report report = ((Notification) object).getEvents().get(0);
-                assertEquals("1.2.3", report.getApp().get("version"));
+                Event event = ((Notification) object).getEvents().get(0);
+                assertEquals("1.2.3", event.getApp().get("version"));
             }
 
             @Override
@@ -140,8 +140,8 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Report report = ((Notification) object).getEvents().get(0);
-                assertEquals("testtype", report.getApp().get("type"));
+                Event event = ((Notification) object).getEvents().get(0);
+                assertEquals("testtype", event.getApp().get("type"));
             }
 
             @Override
@@ -156,8 +156,8 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Report report = ((Notification) object).getEvents().get(0);
-                assertEquals(Severity.INFO.getValue(), report.getSeverity());
+                Event event = ((Notification) object).getEvents().get(0);
+                assertEquals(Severity.INFO.getValue(), event.getSeverity());
             }
 
             @Override
@@ -174,11 +174,11 @@ public class BugsnagTest {
             @SuppressWarnings("unchecked")
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Report report = ((Notification) object).getEvents().get(0);
+                Event event = ((Notification) object).getEvents().get(0);
                 Map<String, Object> firstTab =
-                        (Map<String, Object>) report.getMetadata().get("firsttab");
+                        (Map<String, Object>) event.getMetadata().get("firsttab");
                 final Map<String, Object> secondTab =
-                        (Map<String, Object>) report.getMetadata().get("secondtab");
+                        (Map<String, Object>) event.getMetadata().get("secondtab");
                 assertEquals("[REDACTED]", firstTab.get("testredact1"));
                 assertEquals("[REDACTED]", firstTab.get("testredact2"));
                 assertEquals("secretpassword", firstTab.get("testredact3"));
@@ -204,9 +204,9 @@ public class BugsnagTest {
             @SuppressWarnings("unchecked")
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Report report = ((Notification) object).getEvents().get(0);
+                Event event = ((Notification) object).getEvents().get(0);
                 Map<String, Object> requestTab =
-                        (Map<String, Object>) report.getMetadata().get("request");
+                        (Map<String, Object>) event.getMetadata().get("request");
 
                 Map<String, Object> headersMap =
                         (Map<String, Object>) requestTab.get("headers");
@@ -239,10 +239,10 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Report report = ((Notification) object).getEvents().get(0);
-                assertEquals("123", report.getUser().get("id"));
-                assertEquals("test@example.com", report.getUser().get("email"));
-                assertEquals("test name", report.getUser().get("name"));
+                Event event = ((Notification) object).getEvents().get(0);
+                assertEquals("123", event.getUser().get("id"));
+                assertEquals("test@example.com", event.getUser().get("email"));
+                assertEquals("test name", event.getUser().get("name"));
             }
 
             @Override
@@ -264,8 +264,8 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Report report = ((Notification) object).getEvents().get(0);
-                assertEquals("the context", report.getContext());
+                Event event = ((Notification) object).getEvents().get(0);
+                assertEquals("the context", event.getContext());
             }
 
             @Override
@@ -284,8 +284,8 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Report report = ((Notification) object).getEvents().get(0);
-                assertEquals("the grouping hash", report.getGroupingHash());
+                Event event = ((Notification) object).getEvents().get(0);
+                assertEquals("the grouping hash", event.getGroupingHash());
             }
 
             @Override
@@ -304,8 +304,8 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Report report = ((Notification) object).getEvents().get(0);
-                assertEquals("newapikey", report.getApiKey());
+                Event event = ((Notification) object).getEvents().get(0);
+                assertEquals("newapikey", event.getApiKey());
             }
 
             @Override
@@ -320,8 +320,8 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Report report = ((Notification) object).getEvents().get(0);
-                assertEquals("newapikey", report.getApiKey());
+                Event event = ((Notification) object).getEvents().get(0);
+                assertEquals("newapikey", event.getApiKey());
             }
 
             @Override
@@ -348,8 +348,8 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Report report = ((Notification) object).getEvents().get(0);
-                assertEquals("secondnewapikey", report.getApiKey());
+                Event event = ((Notification) object).getEvents().get(0);
+                assertEquals("secondnewapikey", event.getApiKey());
             }
 
             @Override
@@ -442,9 +442,9 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Report report = ((Notification) object).getEvents().get(0);
+                Event event = ((Notification) object).getEvents().get(0);
                 // There is information about at least one thread
-                assertTrue(report.getThreads().size() > 0);
+                assertTrue(event.getThreads().size() > 0);
             }
 
             @Override
@@ -459,8 +459,8 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Report report = ((Notification) object).getEvents().get(0);
-                assertNull(report.getSession());
+                Event event = ((Notification) object).getEvents().get(0);
+                assertNull(event.getSession());
             }
 
             @Override
@@ -476,9 +476,9 @@ public class BugsnagTest {
         bugsnag.setDelivery(new Delivery() {
             @Override
             public void deliver(Serializer serializer, Object object, Map<String, String> headers) {
-                Report report = ((Notification) object).getEvents().get(0);
+                Event event = ((Notification) object).getEvents().get(0);
 
-                Map<String, Object> session = report.getSession();
+                Map<String, Object> session = event.getSession();
                 assertNotNull(session);
 
                 @SuppressWarnings("unchecked")
@@ -505,9 +505,9 @@ public class BugsnagTest {
         assertTrue(bugsnag.notify(new Throwable()));
 
         for (int i = 0; i < testDelivery.getNotifications().size(); i++) {
-            Report report = testDelivery.getNotifications().get(i).getEvents().get(0);
+            Event event = testDelivery.getNotifications().get(i).getEvents().get(0);
 
-            Map<String, Object> session = report.getSession();
+            Map<String, Object> session = event.getSession();
             assertNotNull(session);
 
             @SuppressWarnings("unchecked")

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagTestUtils.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagTestUtils.java
@@ -25,7 +25,7 @@ class BugsnagTestUtils {
         };
     }
 
-    static JsonNode mapReportToJson(Configuration config, Event event) throws IOException {
+    static JsonNode mapReportToJson(Configuration config, BugsnagEvent event) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         Notification notification = new Notification(config, event);
         String json = mapper.writeValueAsString(notification);

--- a/bugsnag/src/test/java/com/bugsnag/BugsnagTestUtils.java
+++ b/bugsnag/src/test/java/com/bugsnag/BugsnagTestUtils.java
@@ -25,9 +25,9 @@ class BugsnagTestUtils {
         };
     }
 
-    static JsonNode mapReportToJson(Configuration config, Report report) throws IOException {
+    static JsonNode mapReportToJson(Configuration config, Event event) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
-        Notification notification = new Notification(config, report);
+        Notification notification = new Notification(config, event);
         String json = mapper.writeValueAsString(notification);
         return mapper.readTree(json);
     }

--- a/bugsnag/src/test/java/com/bugsnag/CallbackSuppressionTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/CallbackSuppressionTest.java
@@ -30,7 +30,7 @@ public class CallbackSuppressionTest {
 
     @Test
     public void callbackReturningFalseSuppressesDelivery() {
-        bugsnag.addCallback(report -> false); // explicit suppression
+        bugsnag.addOnError(report -> false); // explicit suppression
 
         boolean result = bugsnag.notify(new RuntimeException("Suppressed"));
         assertFalse("notify should return false when suppressed", result);
@@ -39,7 +39,7 @@ public class CallbackSuppressionTest {
 
     @Test
     public void callbackReturningTrueAllowsDelivery() {
-        bugsnag.addCallback(report -> true); // allow
+        bugsnag.addOnError(report -> true); // allow
 
         boolean result = bugsnag.notify(new RuntimeException("Allowed"));
         assertTrue(result);

--- a/bugsnag/src/test/java/com/bugsnag/ConcurrentCallbackTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/ConcurrentCallbackTest.java
@@ -26,10 +26,10 @@ public class ConcurrentCallbackTest {
     public void testClientNotifyModification() {
         final Configuration config = bugsnag.getConfig();
 
-        config.addCallback(report -> {
+        config.addOnError(report -> {
             // modify the callback collection, when iterating to the next callback this
             // should not crash
-            config.addCallback(r -> true);
+            config.addOnError(r -> true);
             return true;
         });
         bugsnag.notify(new RuntimeException());

--- a/bugsnag/src/test/java/com/bugsnag/ConfigurationFeatureFlagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/ConfigurationFeatureFlagTest.java
@@ -25,7 +25,7 @@ public class ConfigurationFeatureFlagTest {
         config.addFeatureFlag("flag1", "variant-a");
 
         // Verify the config has the flag
-        Event event = new Event(config, new RuntimeException("Test"));
+        BugsnagEvent event = new BugsnagEvent(config, new RuntimeException("Test"));
         List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
@@ -37,7 +37,7 @@ public class ConfigurationFeatureFlagTest {
     public void testAddFeatureFlagWithoutVariant() {
         config.addFeatureFlag("flag1");
 
-        Event event = new Event(config, new RuntimeException("Test"));
+        BugsnagEvent event = new BugsnagEvent(config, new RuntimeException("Test"));
         List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
@@ -53,7 +53,7 @@ public class ConfigurationFeatureFlagTest {
 
         config.addFeatureFlags(flagsToAdd);
 
-        Event event = new Event(config, new RuntimeException("Test"));
+        BugsnagEvent event = new BugsnagEvent(config, new RuntimeException("Test"));
         List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(2, flags.size());
@@ -67,7 +67,7 @@ public class ConfigurationFeatureFlagTest {
         config.addFeatureFlag("flag2", "variant-b");
         config.clearFeatureFlag("flag1");
 
-        Event event = new Event(config, new RuntimeException("Test"));
+        BugsnagEvent event = new BugsnagEvent(config, new RuntimeException("Test"));
         List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
@@ -80,7 +80,7 @@ public class ConfigurationFeatureFlagTest {
         config.addFeatureFlag("flag2", "variant-b");
         config.clearFeatureFlags();
 
-        Event event = new Event(config, new RuntimeException("Test"));
+        BugsnagEvent event = new BugsnagEvent(config, new RuntimeException("Test"));
         List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(0, flags.size());

--- a/bugsnag/src/test/java/com/bugsnag/ConfigurationFeatureFlagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/ConfigurationFeatureFlagTest.java
@@ -25,8 +25,8 @@ public class ConfigurationFeatureFlagTest {
         config.addFeatureFlag("flag1", "variant-a");
 
         // Verify the config has the flag
-        Report report = new Report(config, new RuntimeException("Test"));
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        Event event = new Event(config, new RuntimeException("Test"));
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
         assertEquals("flag1", flags.get(0).getName());
@@ -37,8 +37,8 @@ public class ConfigurationFeatureFlagTest {
     public void testAddFeatureFlagWithoutVariant() {
         config.addFeatureFlag("flag1");
 
-        Report report = new Report(config, new RuntimeException("Test"));
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        Event event = new Event(config, new RuntimeException("Test"));
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
         assertEquals("flag1", flags.get(0).getName());
@@ -53,8 +53,8 @@ public class ConfigurationFeatureFlagTest {
 
         config.addFeatureFlags(flagsToAdd);
 
-        Report report = new Report(config, new RuntimeException("Test"));
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        Event event = new Event(config, new RuntimeException("Test"));
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(2, flags.size());
         assertEquals("flag1", flags.get(0).getName());
@@ -67,8 +67,8 @@ public class ConfigurationFeatureFlagTest {
         config.addFeatureFlag("flag2", "variant-b");
         config.clearFeatureFlag("flag1");
 
-        Report report = new Report(config, new RuntimeException("Test"));
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        Event event = new Event(config, new RuntimeException("Test"));
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
         assertEquals("flag2", flags.get(0).getName());
@@ -80,8 +80,8 @@ public class ConfigurationFeatureFlagTest {
         config.addFeatureFlag("flag2", "variant-b");
         config.clearFeatureFlags();
 
-        Report report = new Report(config, new RuntimeException("Test"));
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        Event event = new Event(config, new RuntimeException("Test"));
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(0, flags.size());
     }

--- a/bugsnag/src/test/java/com/bugsnag/EventFeatureFlagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/EventFeatureFlagTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * Tests for feature flags in Report (Event)
  */
-public class ReportFeatureFlagTest {
+public class EventFeatureFlagTest {
 
     private Bugsnag bugsnag;
 
@@ -28,10 +28,10 @@ public class ReportFeatureFlagTest {
 
     @Test
     public void testAddFeatureFlagOnReport() {
-        Report report = bugsnag.buildReport(new RuntimeException("Test"));
-        report.addFeatureFlag("report-flag", "report-variant");
+        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        event.addFeatureFlag("report-flag", "report-variant");
 
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
         assertEquals("report-flag", flags.get(0).getName());
@@ -40,10 +40,10 @@ public class ReportFeatureFlagTest {
 
     @Test
     public void testAddFeatureFlagWithoutVariant() {
-        Report report = bugsnag.buildReport(new RuntimeException("Test"));
-        report.addFeatureFlag("report-flag");
+        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        event.addFeatureFlag("report-flag");
 
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
         assertEquals("report-flag", flags.get(0).getName());
@@ -56,10 +56,10 @@ public class ReportFeatureFlagTest {
         flagsToAdd.add(FeatureFlag.of("flag1", "variant-a"));
         flagsToAdd.add(FeatureFlag.of("flag2", "variant-b"));
 
-        Report report = bugsnag.buildReport(new RuntimeException("Test"));
-        report.addFeatureFlags(flagsToAdd);
+        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        event.addFeatureFlags(flagsToAdd);
 
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(2, flags.size());
         assertEquals("flag1", flags.get(0).getName());
@@ -68,12 +68,12 @@ public class ReportFeatureFlagTest {
 
     @Test
     public void testClearFeatureFlag() {
-        Report report = bugsnag.buildReport(new RuntimeException("Test"));
-        report.addFeatureFlag("flag1", "variant-a");
-        report.addFeatureFlag("flag2", "variant-b");
-        report.clearFeatureFlag("flag1");
+        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        event.addFeatureFlag("flag1", "variant-a");
+        event.addFeatureFlag("flag2", "variant-b");
+        event.clearFeatureFlag("flag1");
 
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
         assertEquals("flag2", flags.get(0).getName());
@@ -81,12 +81,12 @@ public class ReportFeatureFlagTest {
 
     @Test
     public void testClearFeatureFlags() {
-        Report report = bugsnag.buildReport(new RuntimeException("Test"));
-        report.addFeatureFlag("flag1", "variant-a");
-        report.addFeatureFlag("flag2", "variant-b");
-        report.clearFeatureFlags();
+        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        event.addFeatureFlag("flag1", "variant-a");
+        event.addFeatureFlag("flag2", "variant-b");
+        event.clearFeatureFlags();
 
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(0, flags.size());
     }
@@ -95,8 +95,8 @@ public class ReportFeatureFlagTest {
     public void testReportFlagsInheritFromClient() {
         bugsnag.addFeatureFlag("client-flag", "client-variant");
 
-        Report report = bugsnag.buildReport(new RuntimeException("Test"));
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
         assertEquals("client-flag", flags.get(0).getName());
@@ -107,10 +107,10 @@ public class ReportFeatureFlagTest {
     public void testReportFlagsOverrideClientFlags() {
         bugsnag.addFeatureFlag("flag1", "client-variant");
 
-        Report report = bugsnag.buildReport(new RuntimeException("Test"));
-        report.addFeatureFlag("flag1", "report-variant");
+        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        event.addFeatureFlag("flag1", "report-variant");
 
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
         assertEquals("flag1", flags.get(0).getName());
@@ -128,11 +128,11 @@ public class ReportFeatureFlagTest {
         bugsnag.addFeatureFlag("flag3", "client-variant");
 
         // Add flags to report (one new, one override)
-        Report report = bugsnag.buildReport(new RuntimeException("Test"));
-        report.addFeatureFlag("flag3", "report-variant");
-        report.addFeatureFlag("flag4", "report-variant");
+        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        event.addFeatureFlag("flag3", "report-variant");
+        event.addFeatureFlag("flag4", "report-variant");
 
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         // Should have all 4 flags in the order they were first added
         assertEquals(4, flags.size());
@@ -152,10 +152,10 @@ public class ReportFeatureFlagTest {
         bugsnag.getConfig().addFeatureFlag("flag2", "value2");
         bugsnag.getConfig().clearFeatureFlag("flag1");
 
-        Report report = bugsnag.buildReport(new RuntimeException("Test"));
-        report.addFeatureFlag("flag1", "value1-readded");
+        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        event.addFeatureFlag("flag1", "value1-readded");
 
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         // flag1 should now be at the end since it was removed and re-added
         assertEquals(2, flags.size());
@@ -166,13 +166,13 @@ public class ReportFeatureFlagTest {
 
     @Test
     public void testFeatureFlagChaining() {
-        Report report = bugsnag.buildReport(new RuntimeException("Test"));
+        Event event = bugsnag.buildReport(new RuntimeException("Test"));
 
-        report.addFeatureFlag("flag1", "variant-a")
+        event.addFeatureFlag("flag1", "variant-a")
               .addFeatureFlag("flag2", "variant-b")
               .addFeatureFlag("flag3");
 
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(3, flags.size());
         assertEquals("flag1", flags.get(0).getName());
@@ -192,11 +192,11 @@ public class ReportFeatureFlagTest {
 
         // Report adds flag1 with updated value (overrides config value but keeps position)
         // and adds flag2 with updated value
-        Report report = bugsnag.buildReport(new RuntimeException("Test"));
-        report.addFeatureFlag("flag1", "value1-updated");
-        report.addFeatureFlag("flag2", "value2-updated");
+        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        event.addFeatureFlag("flag1", "value1-updated");
+        event.addFeatureFlag("flag2", "value2-updated");
 
-        List<FeatureFlag> flags = report.getFeatureFlags();
+        List<FeatureFlag> flags = event.getFeatureFlags();
 
         // Both flags should maintain their original order from config
         assertEquals(2, flags.size());

--- a/bugsnag/src/test/java/com/bugsnag/EventFeatureFlagTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/EventFeatureFlagTest.java
@@ -28,7 +28,7 @@ public class EventFeatureFlagTest {
 
     @Test
     public void testAddFeatureFlagOnReport() {
-        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = bugsnag.buildReport(new RuntimeException("Test"));
         event.addFeatureFlag("report-flag", "report-variant");
 
         List<FeatureFlag> flags = event.getFeatureFlags();
@@ -40,7 +40,7 @@ public class EventFeatureFlagTest {
 
     @Test
     public void testAddFeatureFlagWithoutVariant() {
-        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = bugsnag.buildReport(new RuntimeException("Test"));
         event.addFeatureFlag("report-flag");
 
         List<FeatureFlag> flags = event.getFeatureFlags();
@@ -56,7 +56,7 @@ public class EventFeatureFlagTest {
         flagsToAdd.add(FeatureFlag.of("flag1", "variant-a"));
         flagsToAdd.add(FeatureFlag.of("flag2", "variant-b"));
 
-        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = bugsnag.buildReport(new RuntimeException("Test"));
         event.addFeatureFlags(flagsToAdd);
 
         List<FeatureFlag> flags = event.getFeatureFlags();
@@ -68,7 +68,7 @@ public class EventFeatureFlagTest {
 
     @Test
     public void testClearFeatureFlag() {
-        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = bugsnag.buildReport(new RuntimeException("Test"));
         event.addFeatureFlag("flag1", "variant-a");
         event.addFeatureFlag("flag2", "variant-b");
         event.clearFeatureFlag("flag1");
@@ -81,7 +81,7 @@ public class EventFeatureFlagTest {
 
     @Test
     public void testClearFeatureFlags() {
-        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = bugsnag.buildReport(new RuntimeException("Test"));
         event.addFeatureFlag("flag1", "variant-a");
         event.addFeatureFlag("flag2", "variant-b");
         event.clearFeatureFlags();
@@ -95,7 +95,7 @@ public class EventFeatureFlagTest {
     public void testReportFlagsInheritFromClient() {
         bugsnag.addFeatureFlag("client-flag", "client-variant");
 
-        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = bugsnag.buildReport(new RuntimeException("Test"));
         List<FeatureFlag> flags = event.getFeatureFlags();
 
         assertEquals(1, flags.size());
@@ -107,7 +107,7 @@ public class EventFeatureFlagTest {
     public void testReportFlagsOverrideClientFlags() {
         bugsnag.addFeatureFlag("flag1", "client-variant");
 
-        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = bugsnag.buildReport(new RuntimeException("Test"));
         event.addFeatureFlag("flag1", "report-variant");
 
         List<FeatureFlag> flags = event.getFeatureFlags();
@@ -128,7 +128,7 @@ public class EventFeatureFlagTest {
         bugsnag.addFeatureFlag("flag3", "client-variant");
 
         // Add flags to report (one new, one override)
-        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = bugsnag.buildReport(new RuntimeException("Test"));
         event.addFeatureFlag("flag3", "report-variant");
         event.addFeatureFlag("flag4", "report-variant");
 
@@ -152,7 +152,7 @@ public class EventFeatureFlagTest {
         bugsnag.getConfig().addFeatureFlag("flag2", "value2");
         bugsnag.getConfig().clearFeatureFlag("flag1");
 
-        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = bugsnag.buildReport(new RuntimeException("Test"));
         event.addFeatureFlag("flag1", "value1-readded");
 
         List<FeatureFlag> flags = event.getFeatureFlags();
@@ -166,7 +166,7 @@ public class EventFeatureFlagTest {
 
     @Test
     public void testFeatureFlagChaining() {
-        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = bugsnag.buildReport(new RuntimeException("Test"));
 
         event.addFeatureFlag("flag1", "variant-a")
               .addFeatureFlag("flag2", "variant-b")
@@ -192,7 +192,7 @@ public class EventFeatureFlagTest {
 
         // Report adds flag1 with updated value (overrides config value but keeps position)
         // and adds flag2 with updated value
-        Event event = bugsnag.buildReport(new RuntimeException("Test"));
+        BugsnagEvent event = bugsnag.buildReport(new RuntimeException("Test"));
         event.addFeatureFlag("flag1", "value1-updated");
         event.addFeatureFlag("flag2", "value2-updated");
 

--- a/bugsnag/src/test/java/com/bugsnag/ExceptionTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/ExceptionTest.java
@@ -76,9 +76,9 @@ public class ExceptionTest {
                 assertEquals("Foo", error.getErrorClass());
                 assertEquals("Test", error.getMessage());
             } catch (Throwable throwable) {
-                report.cancel();
+                return false;
             }
-            return !report.getShouldCancel();
+            return true;
         }));
 
         bugsnag.close();

--- a/bugsnag/src/test/java/com/bugsnag/ExceptionTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/ExceptionTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 public class ExceptionTest {
 
-    private Exception exception;
+    private Error error;
     private RuntimeException ogThrowable;
 
     /**
@@ -28,22 +28,22 @@ public class ExceptionTest {
     public void setUp() {
         Configuration config = new Configuration("api-key");
         ogThrowable = new RuntimeException("Test");
-        exception = new Exception(config, ogThrowable);
+        error = new Error(config, ogThrowable);
     }
 
     @Test
     public void testDefaults() {
-        assertEquals("java.lang.RuntimeException", exception.getErrorClass());
-        assertEquals("Test", exception.getMessage());
-        assertEquals(ogThrowable, exception.getThrowable());
-        assertFalse(exception.getStacktrace().isEmpty());
+        assertEquals("java.lang.RuntimeException", error.getErrorClass());
+        assertEquals("Test", error.getMessage());
+        assertEquals(ogThrowable, error.getThrowable());
+        assertFalse(error.getStacktrace().isEmpty());
     }
 
     @Test
     public void testClassOverride() {
-        exception.setErrorClass("Hello");
-        assertEquals("Hello", exception.getErrorClass());
-        assertEquals("Test", exception.getMessage());
+        error.setErrorClass("Hello");
+        assertEquals("Hello", error.getErrorClass());
+        assertEquals("Test", error.getMessage());
     }
 
     @Test
@@ -68,13 +68,13 @@ public class ExceptionTest {
                 report.setExceptionName("Foo");
                 assertEquals("Foo", report.getExceptionName());
 
-                List<Exception> exceptions = report.getExceptions();
-                assertEquals(1, exceptions.size());
+                List<Error> errors = report.getErrors();
+                assertEquals(1, errors.size());
 
-                Exception exception = exceptions.get(0);
-                assertNotNull(exception);
-                assertEquals("Foo", exception.getErrorClass());
-                assertEquals("Test", exception.getMessage());
+                Error error = errors.get(0);
+                assertNotNull(error);
+                assertEquals("Foo", error.getErrorClass());
+                assertEquals("Test", error.getMessage());
             } catch (Throwable throwable) {
                 report.cancel();
             }

--- a/bugsnag/src/test/java/com/bugsnag/ExceptionTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/ExceptionTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 public class ExceptionTest {
 
-    private Error error;
+    private BugsnagError error;
     private RuntimeException ogThrowable;
 
     /**
@@ -28,7 +28,7 @@ public class ExceptionTest {
     public void setUp() {
         Configuration config = new Configuration("api-key");
         ogThrowable = new RuntimeException("Test");
-        error = new Error(config, ogThrowable);
+        error = new BugsnagError(config, ogThrowable);
     }
 
     @Test
@@ -68,10 +68,10 @@ public class ExceptionTest {
                 report.setExceptionName("Foo");
                 assertEquals("Foo", report.getExceptionName());
 
-                List<Error> errors = report.getErrors();
+                List<BugsnagError> errors = report.getErrors();
                 assertEquals(1, errors.size());
 
-                Error error = errors.get(0);
+                BugsnagError error = errors.get(0);
                 assertNotNull(error);
                 assertEquals("Foo", error.getErrorClass());
                 assertEquals("Test", error.getMessage());

--- a/bugsnag/src/test/java/com/bugsnag/HandledStatePayloadTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/HandledStatePayloadTest.java
@@ -31,7 +31,7 @@ public class HandledStatePayloadTest {
 
     @Test
     public void testBasicSerialisation() throws IOException {
-        Event report = reportFromHandledState(HandledState.newInstance(
+        BugsnagEvent report = reportFromHandledState(HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_UNHANDLED_EXCEPTION));
         JsonNode payload = getJsonPayloadFromReport(report);
 
@@ -41,7 +41,7 @@ public class HandledStatePayloadTest {
 
     @Test
     public void testHandledSerialisation() throws IOException {
-        Event event = reportFromHandledState(HandledState.newInstance(
+        BugsnagEvent event = reportFromHandledState(HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_HANDLED_EXCEPTION));
         JsonNode payload = getJsonPayloadFromReport(event);
 
@@ -58,7 +58,7 @@ public class HandledStatePayloadTest {
 
     @Test
     public void testUnhandledSerialisation() throws IOException {
-        Event event = reportFromHandledState(HandledState.newInstance(
+        BugsnagEvent event = reportFromHandledState(HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_UNHANDLED_EXCEPTION));
         JsonNode payload = getJsonPayloadFromReport(event);
 
@@ -75,7 +75,7 @@ public class HandledStatePayloadTest {
 
     @Test
     public void testUserSpecifiedSerialisation() throws IOException {
-        Event event = reportFromHandledState(HandledState.newInstance(
+        BugsnagEvent event = reportFromHandledState(HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_USER_SPECIFIED, Severity.WARNING));
         JsonNode payload = getJsonPayloadFromReport(event);
 
@@ -92,7 +92,7 @@ public class HandledStatePayloadTest {
 
     @Test
     public void testCallbackSpecified() throws IOException {
-        Event event = reportFromHandledState(HandledState.newInstance(
+        BugsnagEvent event = reportFromHandledState(HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_USER_SPECIFIED));
         event.setSeverity(Severity.INFO);
         JsonNode payload = getJsonPayloadFromReport(event);
@@ -110,7 +110,7 @@ public class HandledStatePayloadTest {
 
     @Test
     public void testUnhandledMiddlewareSerialisation() throws IOException {
-        Event event = reportFromHandledState(HandledState.newInstance(
+        BugsnagEvent event = reportFromHandledState(HandledState.newInstance(
                 SeverityReasonType.REASON_UNHANDLED_EXCEPTION_MIDDLEWARE,
                 Collections.singletonMap("framework", "Spring")));
         JsonNode payload = getJsonPayloadFromReport(event);
@@ -129,7 +129,7 @@ public class HandledStatePayloadTest {
 
     @Test
     public void testUnhandledExceptionClassSerialisation() throws IOException {
-        Event event = reportFromHandledState(HandledState.newInstance(
+        BugsnagEvent event = reportFromHandledState(HandledState.newInstance(
                 SeverityReasonType.REASON_EXCEPTION_CLASS,
                 Collections.singletonMap("exceptionClass", "TypeMismatchException"),
                 Severity.INFO,
@@ -151,7 +151,7 @@ public class HandledStatePayloadTest {
 
     @Test
     public void testHandledExceptionClassSerialisation() throws java.lang.Exception {
-        Event event = reportFromHandledState(HandledState.newInstance(
+        BugsnagEvent event = reportFromHandledState(HandledState.newInstance(
                 SeverityReasonType.REASON_EXCEPTION_CLASS,
                 Collections.singletonMap("exceptionClass", "TypeMismatchException"),
                 Severity.INFO,
@@ -171,11 +171,11 @@ public class HandledStatePayloadTest {
                 severityReason.get("attributes").get("exceptionClass").asText());
     }
 
-    private Event reportFromHandledState(HandledState handledState) {
-        return new Event(config, new RuntimeException(), handledState, Thread.currentThread());
+    private BugsnagEvent reportFromHandledState(HandledState handledState) {
+        return new BugsnagEvent(config, new RuntimeException(), handledState, Thread.currentThread());
     }
 
-    private JsonNode getJsonPayloadFromReport(Event event) throws IOException {
+    private JsonNode getJsonPayloadFromReport(BugsnagEvent event) throws IOException {
         ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
         OutputStreamDelivery delivery = new OutputStreamDelivery(byteStream);
         delivery.deliver(new DefaultSerializer(), event, Collections.<String, String>emptyMap());

--- a/bugsnag/src/test/java/com/bugsnag/HandledStatePayloadTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/HandledStatePayloadTest.java
@@ -31,7 +31,7 @@ public class HandledStatePayloadTest {
 
     @Test
     public void testBasicSerialisation() throws IOException {
-        Report report = reportFromHandledState(HandledState.newInstance(
+        Event report = reportFromHandledState(HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_UNHANDLED_EXCEPTION));
         JsonNode payload = getJsonPayloadFromReport(report);
 
@@ -41,9 +41,9 @@ public class HandledStatePayloadTest {
 
     @Test
     public void testHandledSerialisation() throws IOException {
-        Report report = reportFromHandledState(HandledState.newInstance(
+        Event event = reportFromHandledState(HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_HANDLED_EXCEPTION));
-        JsonNode payload = getJsonPayloadFromReport(report);
+        JsonNode payload = getJsonPayloadFromReport(event);
 
         assertEquals("warning", payload.get("severity").asText());
         assertFalse(payload.get("unhandled").booleanValue());
@@ -58,9 +58,9 @@ public class HandledStatePayloadTest {
 
     @Test
     public void testUnhandledSerialisation() throws IOException {
-        Report report = reportFromHandledState(HandledState.newInstance(
+        Event event = reportFromHandledState(HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_UNHANDLED_EXCEPTION));
-        JsonNode payload = getJsonPayloadFromReport(report);
+        JsonNode payload = getJsonPayloadFromReport(event);
 
         assertEquals("error", payload.get("severity").asText());
         assertTrue(payload.get("unhandled").booleanValue());
@@ -75,9 +75,9 @@ public class HandledStatePayloadTest {
 
     @Test
     public void testUserSpecifiedSerialisation() throws IOException {
-        Report report = reportFromHandledState(HandledState.newInstance(
+        Event event = reportFromHandledState(HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_USER_SPECIFIED, Severity.WARNING));
-        JsonNode payload = getJsonPayloadFromReport(report);
+        JsonNode payload = getJsonPayloadFromReport(event);
 
         assertEquals("warning", payload.get("severity").asText());
         assertFalse(payload.get("unhandled").booleanValue());
@@ -92,10 +92,10 @@ public class HandledStatePayloadTest {
 
     @Test
     public void testCallbackSpecified() throws IOException {
-        Report report = reportFromHandledState(HandledState.newInstance(
+        Event event = reportFromHandledState(HandledState.newInstance(
                 HandledState.SeverityReasonType.REASON_USER_SPECIFIED));
-        report.setSeverity(Severity.INFO);
-        JsonNode payload = getJsonPayloadFromReport(report);
+        event.setSeverity(Severity.INFO);
+        JsonNode payload = getJsonPayloadFromReport(event);
 
         assertEquals("info", payload.get("severity").asText());
         assertFalse(payload.get("unhandled").booleanValue());
@@ -110,10 +110,10 @@ public class HandledStatePayloadTest {
 
     @Test
     public void testUnhandledMiddlewareSerialisation() throws IOException {
-        Report report = reportFromHandledState(HandledState.newInstance(
+        Event event = reportFromHandledState(HandledState.newInstance(
                 SeverityReasonType.REASON_UNHANDLED_EXCEPTION_MIDDLEWARE,
                 Collections.singletonMap("framework", "Spring")));
-        JsonNode payload = getJsonPayloadFromReport(report);
+        JsonNode payload = getJsonPayloadFromReport(event);
 
         assertEquals("error", payload.get("severity").asText());
         assertTrue(payload.get("unhandled").booleanValue());
@@ -129,12 +129,12 @@ public class HandledStatePayloadTest {
 
     @Test
     public void testUnhandledExceptionClassSerialisation() throws IOException {
-        Report report = reportFromHandledState(HandledState.newInstance(
+        Event event = reportFromHandledState(HandledState.newInstance(
                 SeverityReasonType.REASON_EXCEPTION_CLASS,
                 Collections.singletonMap("exceptionClass", "TypeMismatchException"),
                 Severity.INFO,
                 true));
-        JsonNode payload = getJsonPayloadFromReport(report);
+        JsonNode payload = getJsonPayloadFromReport(event);
 
         assertEquals("info", payload.get("severity").asText());
         assertTrue(payload.get("unhandled").booleanValue());
@@ -151,12 +151,12 @@ public class HandledStatePayloadTest {
 
     @Test
     public void testHandledExceptionClassSerialisation() throws java.lang.Exception {
-        Report report = reportFromHandledState(HandledState.newInstance(
+        Event event = reportFromHandledState(HandledState.newInstance(
                 SeverityReasonType.REASON_EXCEPTION_CLASS,
                 Collections.singletonMap("exceptionClass", "TypeMismatchException"),
                 Severity.INFO,
                 false));
-        JsonNode payload = getJsonPayloadFromReport(report);
+        JsonNode payload = getJsonPayloadFromReport(event);
 
         assertEquals("info", payload.get("severity").asText());
         assertFalse(payload.get("unhandled").booleanValue());
@@ -171,14 +171,14 @@ public class HandledStatePayloadTest {
                 severityReason.get("attributes").get("exceptionClass").asText());
     }
 
-    private Report reportFromHandledState(HandledState handledState) {
-        return new Report(config, new RuntimeException(), handledState, Thread.currentThread());
+    private Event reportFromHandledState(HandledState handledState) {
+        return new Event(config, new RuntimeException(), handledState, Thread.currentThread());
     }
 
-    private JsonNode getJsonPayloadFromReport(Report report) throws IOException {
+    private JsonNode getJsonPayloadFromReport(Event event) throws IOException {
         ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
         OutputStreamDelivery delivery = new OutputStreamDelivery(byteStream);
-        delivery.deliver(new DefaultSerializer(), report, Collections.<String, String>emptyMap());
+        delivery.deliver(new DefaultSerializer(), event, Collections.<String, String>emptyMap());
 
         String data = new String(byteStream.toByteArray());
         assertNotNull(data);

--- a/bugsnag/src/test/java/com/bugsnag/JakartaServletCallbackTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/JakartaServletCallbackTest.java
@@ -81,11 +81,11 @@ public class JakartaServletCallbackTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testRequestMetadataAdded() {
-        Report report = generateReport(new java.lang.Exception("Spline reticulation failed"));
+        Event event = generateReport(new java.lang.Exception("Spline reticulation failed"));
         JakartaServletCallback callback = new JakartaServletCallback();
-        callback.onError(report);
+        callback.onError(event);
 
-        Map<String, Object> metadata = report.getMetadata();
+        Map<String, Object> metadata = event.getMetadata();
         assertTrue(metadata.containsKey("request"));
 
         Map<String, Object> request = (Map<String, Object>) metadata.get("request");
@@ -118,24 +118,24 @@ public class JakartaServletCallbackTest {
 
     @Test
     public void testRequestContextSet() {
-        Report report = generateReport(new java.lang.Exception("Spline reticulation failed"));
+        Event event = generateReport(new java.lang.Exception("Spline reticulation failed"));
         JakartaServletCallback callback = new JakartaServletCallback();
-        callback.onError(report);
+        callback.onError(event);
 
-        assertEquals("PATCH /foo/bar", report.getContext());
+        assertEquals("PATCH /foo/bar", event.getContext());
     }
 
     @Test
     public void testExistingContextNotOverridden() {
-        Report report = generateReport(new java.lang.Exception("Spline reticulation failed"));
-        report.setContext("Honey nut corn flakes");
+        Event event = generateReport(new java.lang.Exception("Spline reticulation failed"));
+        event.setContext("Honey nut corn flakes");
         JakartaServletCallback callback = new JakartaServletCallback();
-        callback.onError(report);
+        callback.onError(event);
 
-        assertEquals("Honey nut corn flakes", report.getContext());
+        assertEquals("Honey nut corn flakes", event.getContext());
     }
 
-    private Report generateReport(java.lang.Exception exception) {
+    private Event generateReport(java.lang.Exception exception) {
         return bugsnag.buildReport(exception);
     }
 

--- a/bugsnag/src/test/java/com/bugsnag/JakartaServletCallbackTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/JakartaServletCallbackTest.java
@@ -81,7 +81,7 @@ public class JakartaServletCallbackTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testRequestMetadataAdded() {
-        Event event = generateReport(new java.lang.Exception("Spline reticulation failed"));
+        BugsnagEvent event = generateReport(new java.lang.Exception("Spline reticulation failed"));
         JakartaServletCallback callback = new JakartaServletCallback();
         callback.onError(event);
 
@@ -118,7 +118,7 @@ public class JakartaServletCallbackTest {
 
     @Test
     public void testRequestContextSet() {
-        Event event = generateReport(new java.lang.Exception("Spline reticulation failed"));
+        BugsnagEvent event = generateReport(new java.lang.Exception("Spline reticulation failed"));
         JakartaServletCallback callback = new JakartaServletCallback();
         callback.onError(event);
 
@@ -127,7 +127,7 @@ public class JakartaServletCallbackTest {
 
     @Test
     public void testExistingContextNotOverridden() {
-        Event event = generateReport(new java.lang.Exception("Spline reticulation failed"));
+        BugsnagEvent event = generateReport(new java.lang.Exception("Spline reticulation failed"));
         event.setContext("Honey nut corn flakes");
         JakartaServletCallback callback = new JakartaServletCallback();
         callback.onError(event);
@@ -135,7 +135,7 @@ public class JakartaServletCallbackTest {
         assertEquals("Honey nut corn flakes", event.getContext());
     }
 
-    private Event generateReport(java.lang.Exception exception) {
+    private BugsnagEvent generateReport(java.lang.Exception exception) {
         return bugsnag.buildReport(exception);
     }
 

--- a/bugsnag/src/test/java/com/bugsnag/MarkerTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/MarkerTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.bugsnag.callbacks.Callback;
+import com.bugsnag.callbacks.OnErrorCallback;
 import com.bugsnag.logback.BugsnagMarker;
 
 import org.junit.Before;
@@ -19,7 +19,7 @@ import java.util.Iterator;
 public class MarkerTest {
 
     private BugsnagMarker marker;
-    private Callback callback;
+    private OnErrorCallback callback;
 
     /**
      * Create the marker before the tests

--- a/bugsnag/src/test/java/com/bugsnag/NotificationTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/NotificationTest.java
@@ -16,7 +16,7 @@ import java.util.Date;
 
 public class NotificationTest {
 
-    private Report report;
+    private Event event;
     private Configuration config;
     private final ObjectMapper mapper = new ObjectMapper();
 
@@ -30,7 +30,7 @@ public class NotificationTest {
         config = new Configuration("api-key");
         config.setAppVersion("1.2.3");
         config.setReleaseStage("dev");
-        report = new Report(config, new RuntimeException());
+        event = new Event(config, new RuntimeException());
 
         // Only include properties with non-null values
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
@@ -38,16 +38,16 @@ public class NotificationTest {
 
     private JsonNode generateJson(ObjectMapper mapper,
             Configuration config,
-            Report report) throws IOException {
-        Notification notification = new Notification(config, report);
+            Event event) throws IOException {
+        Notification notification = new Notification(config, event);
         String json = mapper.writeValueAsString(notification);
         return mapper.readTree(json);
     }
 
     @Test
     public void testSessionSerialisation() throws Throwable {
-        report.setSession(new Session("123", new Date(1500000000000L)));
-        JsonNode rootNode = generateJson(mapper, config, report);
+        event.setSession(new Session("123", new Date(1500000000000L)));
+        JsonNode rootNode = generateJson(mapper, config, event);
         validateErrorReport(rootNode);
 
         // check contains a session
@@ -64,17 +64,17 @@ public class NotificationTest {
 
     @Test
     public void testWithoutSessionSerialisation() throws Throwable {
-        report.setSession(new Session("123", new Date()));
-        JsonNode rootNode = generateJson(mapper, config, report);
+        event.setSession(new Session("123", new Date()));
+        JsonNode rootNode = generateJson(mapper, config, event);
         validateErrorReport(rootNode);
         assertNull(rootNode.get("events").get("session"));
     }
 
     @Test
     public void testNullSession() throws Throwable {
-        report.setSession(null);
+        event.setSession(null);
 
-        JsonNode rootNode = generateJson(mapper, config, report);
+        JsonNode rootNode = generateJson(mapper, config, event);
         validateErrorReport(rootNode);
 
         JsonNode session = rootNode.get("events").get(0).get("session");

--- a/bugsnag/src/test/java/com/bugsnag/NotificationTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/NotificationTest.java
@@ -16,7 +16,7 @@ import java.util.Date;
 
 public class NotificationTest {
 
-    private Event event;
+    private BugsnagEvent event;
     private Configuration config;
     private final ObjectMapper mapper = new ObjectMapper();
 
@@ -30,7 +30,7 @@ public class NotificationTest {
         config = new Configuration("api-key");
         config.setAppVersion("1.2.3");
         config.setReleaseStage("dev");
-        event = new Event(config, new RuntimeException());
+        event = new BugsnagEvent(config, new RuntimeException());
 
         // Only include properties with non-null values
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
@@ -38,7 +38,7 @@ public class NotificationTest {
 
     private JsonNode generateJson(ObjectMapper mapper,
             Configuration config,
-            Event event) throws IOException {
+            BugsnagEvent event) throws IOException {
         Notification notification = new Notification(config, event);
         String json = mapper.writeValueAsString(notification);
         return mapper.readTree(json);

--- a/bugsnag/src/test/java/com/bugsnag/NotifierTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/NotifierTest.java
@@ -11,7 +11,7 @@ import java.util.Collections;
 
 public class NotifierTest {
 
-    private Event event;
+    private BugsnagEvent event;
     private Configuration config;
     private SessionPayload sessionPayload;
 
@@ -23,7 +23,7 @@ public class NotifierTest {
     @Before
     public void setUp() throws Throwable {
         config = new Configuration("api-key");
-        event = new Event(config, new RuntimeException());
+        event = new BugsnagEvent(config, new RuntimeException());
         sessionPayload = new SessionPayload(Collections.<SessionCount>emptyList(), config);
     }
 

--- a/bugsnag/src/test/java/com/bugsnag/NotifierTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/NotifierTest.java
@@ -11,7 +11,7 @@ import java.util.Collections;
 
 public class NotifierTest {
 
-    private Report report;
+    private Event event;
     private Configuration config;
     private SessionPayload sessionPayload;
 
@@ -23,13 +23,13 @@ public class NotifierTest {
     @Before
     public void setUp() throws Throwable {
         config = new Configuration("api-key");
-        report = new Report(config, new RuntimeException());
+        event = new Event(config, new RuntimeException());
         sessionPayload = new SessionPayload(Collections.<SessionCount>emptyList(), config);
     }
 
     @Test
     public void testNotificationSerialisation() throws Throwable {
-        JsonNode payload = BugsnagTestUtils.mapReportToJson(config, this.report);
+        JsonNode payload = BugsnagTestUtils.mapReportToJson(config, this.event);
         JsonNode notifier = payload.get("notifier");
 
         assertEquals("Bugsnag Java", notifier.get("name").asText());

--- a/bugsnag/src/test/java/com/bugsnag/ThreadMetadataTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/ThreadMetadataTest.java
@@ -53,14 +53,14 @@ public class ThreadMetadataTest {
 
         // Check the metadata is added to the first report
         Notification notification = delivery.getNotifications().get(0);
-        Report report = notification.getEvents().get(0);
-        assertTrue(report.getMetadata().containsKey("thread"));
+        Event event = notification.getEvents().get(0);
+        assertTrue(event.getMetadata().containsKey("thread"));
         assertEquals("some thread value", getMetadataMap(notification, "thread").get("some key"));
 
         // Check the metadata is not added to the second report
         notification = delivery.getNotifications().get(1);
-        report = notification.getEvents().get(0);
-        assertFalse(report.getMetadata().containsKey("thread"));
+        event = notification.getEvents().get(0);
+        assertFalse(event.getMetadata().containsKey("thread"));
     }
 
     @Test
@@ -79,18 +79,18 @@ public class ThreadMetadataTest {
 
         // Check that both tabs are populated in the first report
         Notification notification = delivery.getNotifications().get(0);
-        Report report = notification.getEvents().get(0);
-        assertTrue(report.getMetadata().containsKey("tab1"));
+        Event event = notification.getEvents().get(0);
+        assertTrue(event.getMetadata().containsKey("tab1"));
         assertEquals("some value", getMetadataMap(notification, "tab1").get("some key"));
-        assertTrue(report.getMetadata().containsKey("tab2"));
+        assertTrue(event.getMetadata().containsKey("tab2"));
         assertEquals("some value", getMetadataMap(notification, "tab2").get("some key"));
 
         // Check that only the first tab is in the second tab
         notification = delivery.getNotifications().get(1);
-        report = notification.getEvents().get(0);
-        assertTrue(report.getMetadata().containsKey("tab1"));
+        event = notification.getEvents().get(0);
+        assertTrue(event.getMetadata().containsKey("tab1"));
         assertEquals("some value", getMetadataMap(notification, "tab1").get("some key"));
-        assertFalse(report.getMetadata().containsKey("tab2"));
+        assertFalse(event.getMetadata().containsKey("tab2"));
     }
 
     @Test
@@ -109,15 +109,15 @@ public class ThreadMetadataTest {
 
         // Check that both keys are populated in the first report
         Notification notification = delivery.getNotifications().get(0);
-        Report report = notification.getEvents().get(0);
-        assertTrue(report.getMetadata().containsKey("tab1"));
+        Event event = notification.getEvents().get(0);
+        assertTrue(event.getMetadata().containsKey("tab1"));
         assertEquals("some value", getMetadataMap(notification, "tab1").get("key1"));
         assertEquals("some value", getMetadataMap(notification, "tab1").get("key2"));
 
         // Check that only the first tab is in the second tab
         notification = delivery.getNotifications().get(1);
-        report = notification.getEvents().get(0);
-        assertTrue(report.getMetadata().containsKey("tab1"));
+        event = notification.getEvents().get(0);
+        assertTrue(event.getMetadata().containsKey("tab1"));
         assertEquals("some value", getMetadataMap(notification, "tab1").get("key1"));
         assertFalse(getMetadataMap(notification, "tab1").containsKey("key2"));
     }
@@ -149,13 +149,13 @@ public class ThreadMetadataTest {
 
         // Check that the data was included in the notification
         Notification notification = delivery.getNotifications().get(0);
-        Report report = notification.getEvents().get(0);
+        Event event = notification.getEvents().get(0);
 
-        assertTrue(report.getMetadata().containsKey("innerthread"));
+        assertTrue(event.getMetadata().containsKey("innerthread"));
         assertEquals("value should be in report",
                 getMetadataMap(notification, "innerthread").get("some key"));
 
-        assertFalse(report.getMetadata().containsKey("outerthread"));
+        assertFalse(event.getMetadata().containsKey("outerthread"));
     }
 
     @Test
@@ -187,9 +187,9 @@ public class ThreadMetadataTest {
 
         // Check that the data was included in the notification
         Notification notification = delivery.getNotifications().get(0);
-        Report report = notification.getEvents().get(0);
+        Event event = notification.getEvents().get(0);
 
-        assertTrue(report.getMetadata().containsKey("thread"));
+        assertTrue(event.getMetadata().containsKey("thread"));
         assertFalse(getMetadataMap(notification, "thread").containsKey("key1"));
         assertEquals("should be included in metadata",
                 getMetadataMap(notification, "thread").get("key2"));
@@ -222,13 +222,13 @@ public class ThreadMetadataTest {
 
         // Check that the data was included in the notification
         Notification notification = delivery.getNotifications().get(0);
-        Report report = notification.getEvents().get(0);
+        Event event = notification.getEvents().get(0);
 
-        assertTrue(report.getMetadata().containsKey("innerthread"));
+        assertTrue(event.getMetadata().containsKey("innerthread"));
         assertEquals("value should be in report",
                 getMetadataMap(notification, "innerthread").get("some key"));
 
-        assertFalse(report.getMetadata().containsKey("outerthread"));
+        assertFalse(event.getMetadata().containsKey("outerthread"));
     }
 
     /**

--- a/bugsnag/src/test/java/com/bugsnag/ThreadMetadataTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/ThreadMetadataTest.java
@@ -53,7 +53,7 @@ public class ThreadMetadataTest {
 
         // Check the metadata is added to the first report
         Notification notification = delivery.getNotifications().get(0);
-        Event event = notification.getEvents().get(0);
+        BugsnagEvent event = notification.getEvents().get(0);
         assertTrue(event.getMetadata().containsKey("thread"));
         assertEquals("some thread value", getMetadataMap(notification, "thread").get("some key"));
 
@@ -79,7 +79,7 @@ public class ThreadMetadataTest {
 
         // Check that both tabs are populated in the first report
         Notification notification = delivery.getNotifications().get(0);
-        Event event = notification.getEvents().get(0);
+        BugsnagEvent event = notification.getEvents().get(0);
         assertTrue(event.getMetadata().containsKey("tab1"));
         assertEquals("some value", getMetadataMap(notification, "tab1").get("some key"));
         assertTrue(event.getMetadata().containsKey("tab2"));
@@ -109,7 +109,7 @@ public class ThreadMetadataTest {
 
         // Check that both keys are populated in the first report
         Notification notification = delivery.getNotifications().get(0);
-        Event event = notification.getEvents().get(0);
+        BugsnagEvent event = notification.getEvents().get(0);
         assertTrue(event.getMetadata().containsKey("tab1"));
         assertEquals("some value", getMetadataMap(notification, "tab1").get("key1"));
         assertEquals("some value", getMetadataMap(notification, "tab1").get("key2"));
@@ -149,7 +149,7 @@ public class ThreadMetadataTest {
 
         // Check that the data was included in the notification
         Notification notification = delivery.getNotifications().get(0);
-        Event event = notification.getEvents().get(0);
+        BugsnagEvent event = notification.getEvents().get(0);
 
         assertTrue(event.getMetadata().containsKey("innerthread"));
         assertEquals("value should be in report",
@@ -160,7 +160,6 @@ public class ThreadMetadataTest {
 
     @Test
     public void testUnhandledThreadMetadataRemoval() {
-
         Thread thread = new Thread(new Runnable() {
             @Override
             public void run() {
@@ -187,7 +186,7 @@ public class ThreadMetadataTest {
 
         // Check that the data was included in the notification
         Notification notification = delivery.getNotifications().get(0);
-        Event event = notification.getEvents().get(0);
+        BugsnagEvent event = notification.getEvents().get(0);
 
         assertTrue(event.getMetadata().containsKey("thread"));
         assertFalse(getMetadataMap(notification, "thread").containsKey("key1"));
@@ -222,7 +221,7 @@ public class ThreadMetadataTest {
 
         // Check that the data was included in the notification
         Notification notification = delivery.getNotifications().get(0);
-        Event event = notification.getEvents().get(0);
+        BugsnagEvent event = notification.getEvents().get(0);
 
         assertTrue(event.getMetadata().containsKey("innerthread"));
         assertEquals("value should be in report",

--- a/bugsnag/src/test/java/com/bugsnag/ThreadStateTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/ThreadStateTest.java
@@ -187,7 +187,7 @@ public class ThreadStateTest {
     }
 
     /**
-     * Verifies that an unhandled error uses {@link com.bugsnag.Exception#getStacktrace()}
+     * Verifies that an unhandled error uses {@link Error#getStacktrace()}
      * for the reporting thread stacktrace
      */
     @Test

--- a/bugsnag/src/test/java/com/bugsnag/ThreadTest.java
+++ b/bugsnag/src/test/java/com/bugsnag/ThreadTest.java
@@ -16,9 +16,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-public class ThreadStateTest {
+public class ThreadTest {
 
-    private List<ThreadState> threadStates;
+    private List<BugsnagThread> threads;
     private Configuration config;
 
     /**
@@ -29,17 +29,17 @@ public class ThreadStateTest {
     @Before
     public void setUp() {
         config = new Configuration("apikey");
-        Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
-        Thread currentThread = Thread.currentThread();
-        threadStates = ThreadState.getLiveThreads(config, currentThread, stackTraces, null);
+        Map<java.lang.Thread, StackTraceElement[]> stackTraces = java.lang.Thread.getAllStackTraces();
+        java.lang.Thread currentThread = java.lang.Thread.currentThread();
+        threads = BugsnagThread.getLiveThreads(config, currentThread, stackTraces, null);
     }
 
     @Test
     public void testThreadStateContainsCurrentThread() {
         int count = 0;
 
-        for (ThreadState thread : threadStates) {
-            if (thread.getId() == Thread.currentThread().getId()) {
+        for (BugsnagThread thread : threads) {
+            if (thread.getId() == java.lang.Thread.currentThread().getId()) {
                 count++;
             }
         }
@@ -48,15 +48,15 @@ public class ThreadStateTest {
 
     @Test
     public void testThreadName() {
-        for (ThreadState threadState : threadStates) {
-            assertNotNull(threadState.getName());
+        for (BugsnagThread thread : threads) {
+            assertNotNull(thread.getName());
         }
     }
 
     @Test
     public void testThreadStacktrace() {
-        for (ThreadState threadState : threadStates) {
-            List<Stackframe> stacktrace = threadState.getStacktrace();
+        for (BugsnagThread thread : threads) {
+            List<Stackframe> stacktrace = thread.getStacktrace();
             assertNotNull(stacktrace);
         }
     }
@@ -66,7 +66,7 @@ public class ThreadStateTest {
      */
     @Test
     public void testSerialisation() throws IOException {
-        JsonNode root = serialiseThreadStateToJson(threadStates);
+        JsonNode root = serialiseThreadStateToJson(threads);
 
         for (JsonNode jsonNode : root) {
             assertNotNull(jsonNode.get("id").asText());
@@ -80,8 +80,8 @@ public class ThreadStateTest {
      */
     @Test
     public void testCurrentThread() throws IOException {
-        JsonNode root = serialiseThreadStateToJson(threadStates);
-        long currentThreadId = Thread.currentThread().getId();
+        JsonNode root = serialiseThreadStateToJson(threads);
+        long currentThreadId = java.lang.Thread.currentThread().getId();
         int currentThreadCount = 0;
 
         for (JsonNode jsonNode : root) {
@@ -101,12 +101,12 @@ public class ThreadStateTest {
      */
     @Test
     public void testDifferentThread() throws IOException {
-        Map<Thread, StackTraceElement[]> threads = Thread.getAllStackTraces();
-        threads.remove(Thread.currentThread());
-        Thread otherThread = threads.keySet().iterator().next();
-        Map<Thread, StackTraceElement[]> allStackTraces = Thread.getAllStackTraces();
-        List<ThreadState> state
-                = ThreadState.getLiveThreads(config, otherThread, allStackTraces, null);
+        Map<java.lang.Thread, StackTraceElement[]> threads = java.lang.Thread.getAllStackTraces();
+        threads.remove(java.lang.Thread.currentThread());
+        java.lang.Thread otherThread = threads.keySet().iterator().next();
+        Map<java.lang.Thread, StackTraceElement[]> allStackTraces = java.lang.Thread.getAllStackTraces();
+        List<BugsnagThread> state
+                = BugsnagThread.getLiveThreads(config, otherThread, allStackTraces, null);
 
         JsonNode root = serialiseThreadStateToJson(state);
         int currentThreadCount = 0;
@@ -124,16 +124,16 @@ public class ThreadStateTest {
 
     /**
      * Verifies that if the current thread is missing from the available traces as reported by
-     * {@link Thread#getAllStackTraces()}, its stacktrace will still be serialised
+     * {@link java.lang.Thread#getAllStackTraces()}, its stacktrace will still be serialised
      */
     @Test
     public void testMissingCurrentThread() throws IOException {
-        Map<Thread, StackTraceElement[]> threads = Thread.getAllStackTraces();
-        Thread currentThread = Thread.currentThread();
+        Map<java.lang.Thread, StackTraceElement[]> threads = java.lang.Thread.getAllStackTraces();
+        java.lang.Thread currentThread = java.lang.Thread.currentThread();
         threads.remove(currentThread);
 
-        List<ThreadState> state
-                = ThreadState.getLiveThreads(config, currentThread, threads, null);
+        List<BugsnagThread> state
+                = BugsnagThread.getLiveThreads(config, currentThread, threads, null);
 
         JsonNode root = serialiseThreadStateToJson(state);
         int currentThreadCount = 0;
@@ -150,17 +150,17 @@ public class ThreadStateTest {
 
 
     /**
-     * Verifies that a handled error uses {@link Thread#getAllStackTraces()}
+     * Verifies that a handled error uses {@link java.lang.Thread#getAllStackTraces()}
      * for the reporting thread stacktrace
      */
     @Test
     public void testHandledStacktrace() throws IOException {
-        Map<Thread, StackTraceElement[]> threads = Thread.getAllStackTraces();
-        Thread currentThread = Thread.currentThread();
+        Map<java.lang.Thread, StackTraceElement[]> threads = java.lang.Thread.getAllStackTraces();
+        java.lang.Thread currentThread = java.lang.Thread.currentThread();
         StackTraceElement[] expectedTrace = threads.get(currentThread);
 
-        List<ThreadState> state
-                = ThreadState.getLiveThreads(config, currentThread, threads, null);
+        List<BugsnagThread> state
+                = BugsnagThread.getLiveThreads(config, currentThread, threads, null);
 
         JsonNode root = serialiseThreadStateToJson(state);
         int currentThreadCount = 0;
@@ -187,18 +187,18 @@ public class ThreadStateTest {
     }
 
     /**
-     * Verifies that an unhandled error uses {@link Error#getStacktrace()}
+     * Verifies that an unhandled error uses {@link BugsnagError#getStacktrace()}
      * for the reporting thread stacktrace
      */
     @Test
     public void testUnhandledStacktrace() throws IOException {
-        Map<Thread, StackTraceElement[]> threads = Thread.getAllStackTraces();
-        Thread currentThread = Thread.currentThread();
+        Map<java.lang.Thread, StackTraceElement[]> threads = java.lang.Thread.getAllStackTraces();
+        java.lang.Thread currentThread = java.lang.Thread.currentThread();
         RuntimeException exc = new RuntimeException("Whoops");
         StackTraceElement[] expectedTrace = exc.getStackTrace();
 
-        List<ThreadState> state
-                = ThreadState.getLiveThreads(config, currentThread, threads, exc);
+        List<BugsnagThread> state
+                = BugsnagThread.getLiveThreads(config, currentThread, threads, exc);
 
         JsonNode root = serialiseThreadStateToJson(state);
         int currentThreadCount = 0;
@@ -225,14 +225,14 @@ public class ThreadStateTest {
     }
 
     @SuppressWarnings("deprecation")
-    private JsonNode serialiseThreadStateToJson(List<ThreadState> threadStates) throws IOException {
+    private JsonNode serialiseThreadStateToJson(List<BugsnagThread> threads) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         mapper
                 .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
                 .setVisibilityChecker(mapper.getVisibilityChecker()
                         .with(JsonAutoDetect.Visibility.NONE));
 
-        String json = mapper.writeValueAsString(threadStates);
+        String json = mapper.writeValueAsString(threads);
         return mapper.readTree(json);
     }
 

--- a/bugsnag/src/test/resources/logback.xml
+++ b/bugsnag/src/test/resources/logback.xml
@@ -33,7 +33,7 @@
             </tab>
         </metadata>
 
-        <sendThreads>true</sendThreads>
+        <sendThreads>ALWAYS</sendThreads>
 
 	</appender>
 

--- a/examples/logback/src/main/java/com/bugsnag/example/logback/cli/Application.java
+++ b/examples/logback/src/main/java/com/bugsnag/example/logback/cli/Application.java
@@ -21,7 +21,7 @@ public class Application {
         Appender appender = rootLogger.getAppender("BUGSNAG");
         if (appender instanceof BugsnagAppender) {
             // Set some global meta data (added to each report)
-            ((BugsnagAppender) appender).getClient().addCallback((report) -> {
+            ((BugsnagAppender) appender).getClient().addOnError((report) -> {
                 report.addMetadata("diagnostics", "timestamp", new Date());
                 report.addMetadata("customer", "name", "acme-inc");
                 report.addMetadata("customer", "paying", true);

--- a/examples/simple/src/main/java/com/bugsnag/example/simple/ExampleApp.java
+++ b/examples/simple/src/main/java/com/bugsnag/example/simple/ExampleApp.java
@@ -3,7 +3,7 @@ package com.bugsnag.example.simple;
 import com.bugsnag.Bugsnag;
 import com.bugsnag.BugsnagEvent;
 import com.bugsnag.Severity;
-import com.bugsnag.callbacks.Callback;
+import com.bugsnag.callbacks.OnErrorCallback;
 
 import java.util.Date;
 
@@ -20,7 +20,7 @@ public class ExampleApp {
         // Create and attach a simple Bugsnag callback.
         // Use Callbacks to send custom diagnostic data which changes during
         // the lifecyle of your application
-        bugsnag.addCallback(new Callback() {
+        bugsnag.addOnError(new OnErrorCallback() {
             @Override
             public boolean onError(BugsnagEvent event) {
                 event.addMetadata("diagnostics", "timestamp", new Date());
@@ -52,7 +52,7 @@ public class ExampleApp {
         try {
             throw new RuntimeException("Handled exception - custom metadata");
         } catch (RuntimeException e) {
-            bugsnag.notify(e, new Callback() {
+            bugsnag.notify(e, new OnErrorCallback() {
                 @Override
                 public boolean onError(BugsnagEvent event) {
                     event.setSeverity(Severity.WARNING);

--- a/examples/simple/src/main/java/com/bugsnag/example/simple/ExampleApp.java
+++ b/examples/simple/src/main/java/com/bugsnag/example/simple/ExampleApp.java
@@ -1,7 +1,7 @@
 package com.bugsnag.example.simple;
 
 import com.bugsnag.Bugsnag;
-import com.bugsnag.Report;
+import com.bugsnag.Event;
 import com.bugsnag.Severity;
 import com.bugsnag.callbacks.Callback;
 
@@ -22,14 +22,14 @@ public class ExampleApp {
         // the lifecyle of your application
         bugsnag.addCallback(new Callback() {
             @Override
-            public boolean onError(Report report) {
-                report.addMetadata("diagnostics", "timestamp", new Date());
-                report.addMetadata("customer", "name", "acme-inc");
-                report.addMetadata("customer", "paying", true);
-                report.addMetadata("customer", "spent", 1234);
-                report.setUserName("User Name");
-                report.setUserEmail("user@example.com");
-                report.setUserId("12345");
+            public boolean onError(Event event) {
+                event.addMetadata("diagnostics", "timestamp", new Date());
+                event.addMetadata("customer", "name", "acme-inc");
+                event.addMetadata("customer", "paying", true);
+                event.addMetadata("customer", "spent", 1234);
+                event.setUserName("User Name");
+                event.setUserEmail("user@example.com");
+                event.setUserId("12345");
                 return true;
             }
         });
@@ -54,10 +54,10 @@ public class ExampleApp {
         } catch (RuntimeException e) {
             bugsnag.notify(e, new Callback() {
                 @Override
-                public boolean onError(Report report) {
-                    report.setSeverity(Severity.WARNING);
-                    report.addMetadata("report", "something", "that happened");
-                    report.setContext("the context");
+                public boolean onError(Event event) {
+                    event.setSeverity(Severity.WARNING);
+                    event.addMetadata("report", "something", "that happened");
+                    event.setContext("the context");
                     return true;
                 }
             });

--- a/examples/simple/src/main/java/com/bugsnag/example/simple/ExampleApp.java
+++ b/examples/simple/src/main/java/com/bugsnag/example/simple/ExampleApp.java
@@ -1,7 +1,7 @@
 package com.bugsnag.example.simple;
 
 import com.bugsnag.Bugsnag;
-import com.bugsnag.Event;
+import com.bugsnag.BugsnagEvent;
 import com.bugsnag.Severity;
 import com.bugsnag.callbacks.Callback;
 
@@ -22,7 +22,7 @@ public class ExampleApp {
         // the lifecyle of your application
         bugsnag.addCallback(new Callback() {
             @Override
-            public boolean onError(Event event) {
+            public boolean onError(BugsnagEvent event) {
                 event.addMetadata("diagnostics", "timestamp", new Date());
                 event.addMetadata("customer", "name", "acme-inc");
                 event.addMetadata("customer", "paying", true);
@@ -54,7 +54,7 @@ public class ExampleApp {
         } catch (RuntimeException e) {
             bugsnag.notify(e, new Callback() {
                 @Override
-                public boolean onError(Event event) {
+                public boolean onError(BugsnagEvent event) {
                     event.setSeverity(Severity.WARNING);
                     event.addMetadata("report", "something", "that happened");
                     event.setContext("the context");

--- a/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/ApplicationRestController.java
+++ b/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/ApplicationRestController.java
@@ -1,7 +1,7 @@
 package com.bugsnag.example.spring.web;
 
 import com.bugsnag.Bugsnag;
-import com.bugsnag.Event;
+import com.bugsnag.BugsnagEvent;
 import com.bugsnag.Severity;
 import com.bugsnag.callbacks.Callback;
 
@@ -71,7 +71,7 @@ public class ApplicationRestController {
         } catch (RuntimeException e) {
             bugsnag.notify(e, new Callback() {
                 @Override
-                public boolean onError(Event event) {
+                public boolean onError(BugsnagEvent event) {
                     event.setSeverity(Severity.WARNING);
                     event.addMetadata("report", "something", "that happened");
                     event.setContext("the context");

--- a/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/ApplicationRestController.java
+++ b/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/ApplicationRestController.java
@@ -1,7 +1,7 @@
 package com.bugsnag.example.spring.web;
 
 import com.bugsnag.Bugsnag;
-import com.bugsnag.Report;
+import com.bugsnag.Event;
 import com.bugsnag.Severity;
 import com.bugsnag.callbacks.Callback;
 
@@ -71,10 +71,10 @@ public class ApplicationRestController {
         } catch (RuntimeException e) {
             bugsnag.notify(e, new Callback() {
                 @Override
-                public boolean onError(Report report) {
-                    report.setSeverity(Severity.WARNING);
-                    report.addMetadata("report", "something", "that happened");
-                    report.setContext("the context");
+                public boolean onError(Event event) {
+                    event.setSeverity(Severity.WARNING);
+                    event.addMetadata("report", "something", "that happened");
+                    event.setContext("the context");
                     return true;
                 }
             });

--- a/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/ApplicationRestController.java
+++ b/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/ApplicationRestController.java
@@ -3,7 +3,7 @@ package com.bugsnag.example.spring.web;
 import com.bugsnag.Bugsnag;
 import com.bugsnag.BugsnagEvent;
 import com.bugsnag.Severity;
-import com.bugsnag.callbacks.Callback;
+import com.bugsnag.callbacks.OnErrorCallback;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,7 +69,7 @@ public class ApplicationRestController {
         try {
             throw new RuntimeException("Handled exception - custom metadata");
         } catch (RuntimeException e) {
-            bugsnag.notify(e, new Callback() {
+            bugsnag.notify(e, new OnErrorCallback() {
                 @Override
                 public boolean onError(BugsnagEvent event) {
                     event.setSeverity(Severity.WARNING);

--- a/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Config.java
+++ b/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Config.java
@@ -3,7 +3,7 @@ package com.bugsnag.example.spring.web;
 import com.bugsnag.Bugsnag;
 import com.bugsnag.BugsnagSpringConfiguration;
 import com.bugsnag.BugsnagEvent;
-import com.bugsnag.callbacks.Callback;
+import com.bugsnag.callbacks.OnErrorCallback;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,7 +29,7 @@ public class Config {
         // Create and attach a simple Bugsnag callback.
         // Use Callbacks to send custom diagnostic data which changes during
         // the lifecyle of your application
-        bugsnag.addCallback(new Callback() {
+        bugsnag.addOnError(new OnErrorCallback() {
             @Override
             public boolean onError(BugsnagEvent event) {
                 event.addMetadata("diagnostics", "timestamp", new Date());

--- a/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Config.java
+++ b/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Config.java
@@ -2,7 +2,7 @@ package com.bugsnag.example.spring.web;
 
 import com.bugsnag.Bugsnag;
 import com.bugsnag.BugsnagSpringConfiguration;
-import com.bugsnag.Report;
+import com.bugsnag.Event;
 import com.bugsnag.callbacks.Callback;
 
 import org.springframework.context.annotation.Bean;
@@ -31,14 +31,14 @@ public class Config {
         // the lifecyle of your application
         bugsnag.addCallback(new Callback() {
             @Override
-            public boolean onError(Report report) {
-                report.addMetadata("diagnostics", "timestamp", new Date());
-                report.addMetadata("customer", "name", "acme-inc");
-                report.addMetadata("customer", "paying", true);
-                report.addMetadata("customer", "spent", 1234);
-                report.setUserName("User Name");
-                report.setUserEmail("user@example.com");
-                report.setUserId("12345");
+            public boolean onError(Event event) {
+                event.addMetadata("diagnostics", "timestamp", new Date());
+                event.addMetadata("customer", "name", "acme-inc");
+                event.addMetadata("customer", "paying", true);
+                event.addMetadata("customer", "spent", 1234);
+                event.setUserName("User Name");
+                event.setUserEmail("user@example.com");
+                event.setUserId("12345");
                 return true;
             }
         });

--- a/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Config.java
+++ b/examples/spring-web/src/main/java/com/bugsnag/example/spring/web/Config.java
@@ -2,7 +2,7 @@ package com.bugsnag.example.spring.web;
 
 import com.bugsnag.Bugsnag;
 import com.bugsnag.BugsnagSpringConfiguration;
-import com.bugsnag.Event;
+import com.bugsnag.BugsnagEvent;
 import com.bugsnag.callbacks.Callback;
 
 import org.springframework.context.annotation.Bean;
@@ -31,7 +31,7 @@ public class Config {
         // the lifecyle of your application
         bugsnag.addCallback(new Callback() {
             @Override
-            public boolean onError(Event event) {
+            public boolean onError(BugsnagEvent event) {
                 event.addMetadata("diagnostics", "timestamp", new Date());
                 event.addMetadata("customer", "name", "acme-inc");
                 event.addMetadata("customer", "paying", true);

--- a/examples/spring/src/main/java/com/bugsnag/example/spring/cli/ApplicationCommandLineRunner.java
+++ b/examples/spring/src/main/java/com/bugsnag/example/spring/cli/ApplicationCommandLineRunner.java
@@ -1,7 +1,7 @@
 package com.bugsnag.example.spring.cli;
 
 import com.bugsnag.Bugsnag;
-import com.bugsnag.Event;
+import com.bugsnag.BugsnagEvent;
 import com.bugsnag.Severity;
 import com.bugsnag.callbacks.Callback;
 
@@ -50,7 +50,7 @@ public class ApplicationCommandLineRunner implements CommandLineRunner {
         } catch (RuntimeException e) {
             bugsnag.notify(e, new Callback() {
                 @Override
-                public boolean onError(Event event) {
+                public boolean onError(BugsnagEvent event) {
                     event.setSeverity(Severity.WARNING);
                     event.addMetadata("report", "something", "that happened");
                     event.setContext("the context");

--- a/examples/spring/src/main/java/com/bugsnag/example/spring/cli/ApplicationCommandLineRunner.java
+++ b/examples/spring/src/main/java/com/bugsnag/example/spring/cli/ApplicationCommandLineRunner.java
@@ -3,7 +3,7 @@ package com.bugsnag.example.spring.cli;
 import com.bugsnag.Bugsnag;
 import com.bugsnag.BugsnagEvent;
 import com.bugsnag.Severity;
-import com.bugsnag.callbacks.Callback;
+import com.bugsnag.callbacks.OnErrorCallback;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +48,7 @@ public class ApplicationCommandLineRunner implements CommandLineRunner {
         try {
             throw new RuntimeException("Handled exception - custom metadata");
         } catch (RuntimeException e) {
-            bugsnag.notify(e, new Callback() {
+            bugsnag.notify(e, new OnErrorCallback() {
                 @Override
                 public boolean onError(BugsnagEvent event) {
                     event.setSeverity(Severity.WARNING);

--- a/examples/spring/src/main/java/com/bugsnag/example/spring/cli/ApplicationCommandLineRunner.java
+++ b/examples/spring/src/main/java/com/bugsnag/example/spring/cli/ApplicationCommandLineRunner.java
@@ -1,7 +1,7 @@
 package com.bugsnag.example.spring.cli;
 
 import com.bugsnag.Bugsnag;
-import com.bugsnag.Report;
+import com.bugsnag.Event;
 import com.bugsnag.Severity;
 import com.bugsnag.callbacks.Callback;
 
@@ -50,10 +50,10 @@ public class ApplicationCommandLineRunner implements CommandLineRunner {
         } catch (RuntimeException e) {
             bugsnag.notify(e, new Callback() {
                 @Override
-                public boolean onError(Report report) {
-                    report.setSeverity(Severity.WARNING);
-                    report.addMetadata("report", "something", "that happened");
-                    report.setContext("the context");
+                public boolean onError(Event event) {
+                    event.setSeverity(Severity.WARNING);
+                    event.addMetadata("report", "something", "that happened");
+                    event.setContext("the context");
                     return true;
                 }
             });

--- a/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Config.java
+++ b/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Config.java
@@ -2,7 +2,7 @@ package com.bugsnag.example.spring.cli;
 
 import com.bugsnag.Bugsnag;
 import com.bugsnag.BugsnagSpringConfiguration;
-import com.bugsnag.Report;
+import com.bugsnag.Event;
 import com.bugsnag.callbacks.Callback;
 
 import org.springframework.context.annotation.Bean;
@@ -32,14 +32,14 @@ public class Config {
         // the lifecyle of your application
         bugsnag.addCallback(new Callback() {
             @Override
-            public boolean onError(Report report) {
-                report.addMetadata("diagnostics", "timestamp", new Date());
-                report.addMetadata("customer", "name", "acme-inc");
-                report.addMetadata("customer", "paying", true);
-                report.addMetadata("customer", "spent", 1234);
-                report.setUserName("User Name");
-                report.setUserEmail("user@example.com");
-                report.setUserId("12345");
+            public boolean onError(Event event) {
+                event.addMetadata("diagnostics", "timestamp", new Date());
+                event.addMetadata("customer", "name", "acme-inc");
+                event.addMetadata("customer", "paying", true);
+                event.addMetadata("customer", "spent", 1234);
+                event.setUserName("User Name");
+                event.setUserEmail("user@example.com");
+                event.setUserId("12345");
                 return true;
             }
         });

--- a/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Config.java
+++ b/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Config.java
@@ -2,7 +2,7 @@ package com.bugsnag.example.spring.cli;
 
 import com.bugsnag.Bugsnag;
 import com.bugsnag.BugsnagSpringConfiguration;
-import com.bugsnag.Event;
+import com.bugsnag.BugsnagEvent;
 import com.bugsnag.callbacks.Callback;
 
 import org.springframework.context.annotation.Bean;
@@ -32,7 +32,7 @@ public class Config {
         // the lifecyle of your application
         bugsnag.addCallback(new Callback() {
             @Override
-            public boolean onError(Event event) {
+            public boolean onError(BugsnagEvent event) {
                 event.addMetadata("diagnostics", "timestamp", new Date());
                 event.addMetadata("customer", "name", "acme-inc");
                 event.addMetadata("customer", "paying", true);

--- a/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Config.java
+++ b/examples/spring/src/main/java/com/bugsnag/example/spring/cli/Config.java
@@ -3,7 +3,7 @@ package com.bugsnag.example.spring.cli;
 import com.bugsnag.Bugsnag;
 import com.bugsnag.BugsnagSpringConfiguration;
 import com.bugsnag.BugsnagEvent;
-import com.bugsnag.callbacks.Callback;
+import com.bugsnag.callbacks.OnErrorCallback;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,7 +30,7 @@ public class Config {
         // Create and attach a simple Bugsnag callback.
         // Use Callbacks to send custom diagnostic data which changes during
         // the lifecyle of your application
-        bugsnag.addCallback(new Callback() {
+        bugsnag.addOnError(new OnErrorCallback() {
             @Override
             public boolean onError(BugsnagEvent event) {
                 event.addMetadata("diagnostics", "timestamp", new Date());

--- a/features/fixtures/logback/threads_config.xml
+++ b/features/fixtures/logback/threads_config.xml
@@ -9,7 +9,7 @@
 
 		<endpoint>http://localhost:9339/notify</endpoint>
 
-        <sendThreads>true</sendThreads>
+        <sendThreads>ALWAYS</sendThreads>
 	</appender>
 
 	<root level="INFO">

--- a/features/fixtures/mazerunnerspringboot3/src/main/java/com/bugsnag/mazerunner/scenarios/ScheduledTaskExecutorScenario.java
+++ b/features/fixtures/mazerunnerspringboot3/src/main/java/com/bugsnag/mazerunner/scenarios/ScheduledTaskExecutorScenario.java
@@ -1,9 +1,8 @@
 package com.bugsnag.mazerunner.scenarios;
 
 import com.bugsnag.Bugsnag;
-import com.bugsnag.Report;
-import com.bugsnag.callbacks.Callback;
 import com.bugsnag.mazerunnerspringboot.ScheduledTaskExecutorService;
+
 import java.util.Collection;
 
 public class ScheduledTaskExecutorScenario extends Scenario {
@@ -25,13 +24,10 @@ public class ScheduledTaskExecutorScenario extends Scenario {
         }
 
         final Collection<String> threadnames = ScheduledTaskExecutorService.getThreadNames();
-        bugsnag.notify(new RuntimeException("Whoops"), new Callback() {
-            @Override
-            public boolean onError(Report report) {
-                report.addMetadata("executor", "multiThreaded", threadnames.size() > 1);
-                report.addMetadata("executor", "names", threadnames);
-                return true;
-            }
+        bugsnag.notify(new RuntimeException("Whoops"), (event) -> {
+            event.addMetadata("executor", "multiThreaded", threadnames.size() > 1);
+            event.addMetadata("executor", "names", threadnames);
+            return true;
         });
     }
 }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/AutoRedactScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/AutoRedactScenario.java
@@ -1,8 +1,8 @@
 package com.bugsnag.mazerunner.scenarios;
 
 import com.bugsnag.Bugsnag;
-import com.bugsnag.Report;
-import com.bugsnag.callbacks.Callback;
+import com.bugsnag.BugsnagEvent;
+import com.bugsnag.callbacks.OnErrorCallback;
 
 /**
  * Sends a handled exception to Bugsnag, which contains metadata that should be redacted
@@ -15,14 +15,11 @@ public class AutoRedactScenario extends Scenario {
 
     @Override
     public void run() {
-        bugsnag.notify(generateException(), new Callback() {
-            @Override
-            public boolean onError(Report report) {
-                report.addMetadata("user", "password", "hunter2");
-                report.addMetadata("custom", "password", "hunter2");
-                report.addMetadata("custom", "foo", "hunter2");
-                return true;
-            }
+        bugsnag.notify(generateException(), event -> {
+            event.addMetadata("user", "password", "hunter2");
+            event.addMetadata("custom", "password", "hunter2");
+            event.addMetadata("custom", "foo", "hunter2");
+            return true;
         });
     }
 }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/LogbackMetadataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/LogbackMetadataScenario.java
@@ -1,10 +1,7 @@
 package com.bugsnag.mazerunner.scenarios;
 
 import com.bugsnag.Bugsnag;
-import com.bugsnag.Report;
-import com.bugsnag.callbacks.Callback;
 import com.bugsnag.logback.BugsnagMarker;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,14 +18,11 @@ public class LogbackMetadataScenario extends Scenario {
 
     @Override
     public void run() {
-        LOGGER.warn(new BugsnagMarker(new Callback() {
-            @Override
-            public boolean onError(Report report) {
-                report.addMetadata("user", "foo", "hunter2");
-                report.addMetadata("custom", "foo", "hunter2");
-                report.addMetadata("custom", "bar", "hunter2");
-                return true;
-            }
+        LOGGER.warn(new BugsnagMarker(event -> {
+            event.addMetadata("user", "foo", "hunter2");
+            event.addMetadata("custom", "foo", "hunter2");
+            event.addMetadata("custom", "bar", "hunter2");
+            return true;
         }), "Error sent to Bugsnag using the logback appender", generateException());
     }
 }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ManualContextScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ManualContextScenario.java
@@ -1,8 +1,6 @@
 package com.bugsnag.mazerunner.scenarios;
 
 import com.bugsnag.Bugsnag;
-import com.bugsnag.Report;
-import com.bugsnag.callbacks.Callback;
 
 /**
  * Sends a handled exception to Bugsnag, which includes manual context.
@@ -15,12 +13,9 @@ public class ManualContextScenario extends Scenario {
 
     @Override
     public void run() {
-        bugsnag.notify(generateException(), new Callback() {
-            @Override
-            public boolean onError(Report report) {
-                report.setContext("FooContext");
-                return true;
-            }
+        bugsnag.notify(generateException(), event -> {
+            event.setContext("FooContext");
+            return true;
         });
     }
 }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ManualRedactScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ManualRedactScenario.java
@@ -1,8 +1,6 @@
 package com.bugsnag.mazerunner.scenarios;
 
 import com.bugsnag.Bugsnag;
-import com.bugsnag.Report;
-import com.bugsnag.callbacks.Callback;
 
 /**
  * Sends a handled exception to Bugsnag, which contains metadata that should be redacted
@@ -18,14 +16,11 @@ public class ManualRedactScenario extends Scenario {
 
         bugsnag.setRedactedKeys("foo");
 
-        bugsnag.notify(generateException(), new Callback() {
-            @Override
-            public boolean onError(Report report) {
-                report.addMetadata("user", "foo", "hunter2");
-                report.addMetadata("custom", "foo", "hunter2");
-                report.addMetadata("custom", "bar", "hunter2");
-                return true;
-            }
+        bugsnag.notify(generateException(), event -> {
+            event.addMetadata("user", "foo", "hunter2");
+            event.addMetadata("custom", "foo", "hunter2");
+            event.addMetadata("custom", "bar", "hunter2");
+            return true;
         });
     }
 }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/MetadataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/MetadataScenario.java
@@ -1,8 +1,6 @@
 package com.bugsnag.mazerunner.scenarios;
 
 import com.bugsnag.Bugsnag;
-import com.bugsnag.Report;
-import com.bugsnag.callbacks.Callback;
 
 /**
  * Sends a handled exception to Bugsnag, which includes custom metadata
@@ -15,12 +13,9 @@ public class MetadataScenario extends Scenario {
 
     @Override
     public void run() {
-        bugsnag.notify(generateException(), new Callback() {
-            @Override
-            public boolean onError(Report report) {
-                report.addMetadata("Custom", "foo", "Hello World!");
-                return true;
-            }
+        bugsnag.notify(generateException(), event -> {
+            event.addMetadata("Custom", "foo", "Hello World!");
+            return true;
         });
     }
 }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ThreadMetadataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ThreadMetadataScenario.java
@@ -1,8 +1,6 @@
 package com.bugsnag.mazerunner.scenarios;
 
 import com.bugsnag.Bugsnag;
-import com.bugsnag.callbacks.Callback;
-import com.bugsnag.Report;
 
 /**
  * Sends an exception to Bugsnag with custom metadata on the thread
@@ -16,13 +14,10 @@ public class ThreadMetadataScenario extends Scenario {
     @Override
     public void run() {
         // Global callback metadata has lowest precedence
-        bugsnag.addCallback(new Callback() {
-            @Override
-            public boolean onError(Report report) {
-                report.addMetadata("Custom", "test", "Global value");
-                report.addMetadata("Custom", "foo", "Global value to be overwritten");
-                return true;
-            }
+        bugsnag.addOnError((event) -> {
+            event.addMetadata("Custom", "test", "Global value");
+            event.addMetadata("Custom", "foo", "Global value to be overwritten");
+            return true;
         });
 
         // Thread metadata should merge with global metadata and overwrite when duplicate key
@@ -46,12 +41,9 @@ public class ThreadMetadataScenario extends Scenario {
         }
 
         // Report-specific metadata should merge with global + thread metadata and overwrite when duplicate key
-        bugsnag.notify(generateException(), new Callback() {
-            @Override
-            public boolean onError(Report report) {
-                report.addMetadata("Custom", "bar", "Hello World!");
-                return true;
-            }
+        bugsnag.notify(generateException(), (event) -> {
+            event.addMetadata("Custom", "bar", "Hello World!");
+            return true;
         });
     }
 }

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ThreadsScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/ThreadsScenario.java
@@ -1,8 +1,7 @@
 package com.bugsnag.mazerunner.scenarios;
 
 import com.bugsnag.Bugsnag;
-import com.bugsnag.Report;
-import com.bugsnag.callbacks.Callback;
+import com.bugsnag.ThreadSendPolicy;
 
 /**
  * Sends a handled exception to Bugsnag, which overrides the default user via a callback
@@ -11,7 +10,7 @@ public class ThreadsScenario extends Scenario {
 
     public ThreadsScenario(Bugsnag bugsnag) {
         super(bugsnag);
-        bugsnag.setSendThreads(true);
+        bugsnag.setSendThreads(ThreadSendPolicy.ALWAYS);
     }
 
     @Override

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UnhandledThreadMetadataScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UnhandledThreadMetadataScenario.java
@@ -1,8 +1,6 @@
 package com.bugsnag.mazerunner.scenarios;
 
 import com.bugsnag.Bugsnag;
-import com.bugsnag.callbacks.Callback;
-import com.bugsnag.Report;
 
 /**
  * Sends an unhandled exception to Bugsnag with custom metadata on the thread
@@ -16,22 +14,21 @@ public class UnhandledThreadMetadataScenario extends Scenario {
     @Override
     public void run() {
         // Global callback metadata has lowest precedence
-        bugsnag.addCallback(new Callback() {
-            @Override
-            public boolean onError(Report report) {
-                report.addMetadata("Custom", "test", "Global value");
-                report.addMetadata("Custom", "foo", "Global value to be overwritten");
-                return true;
-            }
+        bugsnag.addOnError((event) -> {
+            event.addMetadata("Custom", "test", "Global value");
+            event.addMetadata("Custom", "foo", "Global value to be overwritten");
+            return true;
         });
 
         // Thread metadata on a different thread should not get added
-        Thread t1 = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                Bugsnag.addThreadMetadata("Custom", "something", "This should not be on the report");
-            }
-        });
+        Thread t1 = new Thread(() ->
+                Bugsnag.addThreadMetadata(
+                        "Custom",
+                        "something",
+                        "This should not be on the report"
+                )
+        );
+
         t1.start();
 
         try {
@@ -40,14 +37,11 @@ public class UnhandledThreadMetadataScenario extends Scenario {
             // ignore
         }
 
-        Thread t2 = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                // Thread metadata should merge with global metadata and overwrite when duplicate key
-                Bugsnag.addThreadMetadata("Custom", "foo", "Thread value 1");
-                Bugsnag.addThreadMetadata("Custom", "bar", "Thread value 2");
-                throw new RuntimeException("UnhandledThreadMetadataScenario");
-            }
+        Thread t2 = new Thread(() -> {
+            // Thread metadata should merge with global metadata and overwrite when duplicate key
+            Bugsnag.addThreadMetadata("Custom", "foo", "Thread value 1");
+            Bugsnag.addThreadMetadata("Custom", "bar", "Thread value 2");
+            throw new RuntimeException("UnhandledThreadMetadataScenario");
         });
         t2.start();
 

--- a/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UserCallbackScenario.java
+++ b/features/fixtures/scenarios/src/main/java/com/bugsnag/mazerunner/scenarios/UserCallbackScenario.java
@@ -1,8 +1,6 @@
 package com.bugsnag.mazerunner.scenarios;
 
 import com.bugsnag.Bugsnag;
-import com.bugsnag.Report;
-import com.bugsnag.callbacks.Callback;
 
 /**
  * Sends a handled exception to Bugsnag, which overrides the default user via a callback
@@ -15,12 +13,9 @@ public class UserCallbackScenario extends Scenario {
 
     @Override
     public void run() {
-        bugsnag.notify(generateException(), new Callback() {
-            @Override
-            public boolean onError(Report report) {
-                report.setUser("Agent Pink", "bob@example.com", "Zebedee");
-                return true;
-            }
+        bugsnag.notify(generateException(), (event) -> {
+            event.setUser("Agent Pink", "bob@example.com", "Zebedee");
+            return true;
         });
     }
 }


### PR DESCRIPTION
## Goal
Bring the primary classes & properties inline with other platforms.

## Changeset
Renamed classes:

- `Report` -> `BugsnagEvent`
- `Exception` -> `BugsnagError`
- `ThreadState` -> `BugsnagThread`
- `Callback` -> `OnErrorCallback`

Renamed method `addCallback` -> `addOnError`.

Removed `Report.cancel()`.

## Testing
Updated the tests for the new SDK.