### PR TITLE
Removed the duplicate apply(release.gradle.kts)

### DIFF
--- a/common.gradle.kts
+++ b/common.gradle.kts
@@ -1,9 +1,6 @@
 // Version catalog is now used - see gradle/libs.versions.toml
 apply(plugin = "checkstyle")
 
-if (project.hasProperty("releasing") && project.depth <= 1) {
-    apply(from = "../release.gradle.kts")
-}
 tasks.named<Test>("test") {
     testLogging {
         events("passed", "skipped", "failed", "standardOut", "standardError")


### PR DESCRIPTION
## Goal
Unblock release by fixing the Gradle script.

## Design
Remove the duplicate `apply("release.gradle.kts")` from the `common.gradle.kts` file. Each module needs to now include `release.gradle.kts` manually (which they were already doing).

## Testing
Published in release mode locally.