### PR TITLE
Fix the publishing docker image (jq)

### DIFF
--- a/dockerfiles/Dockerfile.java-common
+++ b/dockerfiles/Dockerfile.java-common
@@ -2,7 +2,7 @@ FROM eclipse-temurin:17.0.13_11-jdk-jammy
 WORKDIR /app
 
 RUN apt-get update > /dev/null
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y zip
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget maven gnupg1 cppcheck libncurses5 jq unzip curl zip
 
 # Force download of gradle zip early to avoid repeating
 # if Docker cache is invalidated by branch changes.


### PR DESCRIPTION
## Goal
Unblock release by fixing the publishing docker image.

## Changeset
Added `wget maven gnupg1 cppcheck libncurses5 jq unzip curl zip` to the publishing docker image to match `bugsnag-android`