### PR TITLE
Fix the docker-release script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.0.0 - 2025-08-04
+## 4.0.0 - 2026-04-29
 
 * This major release modernises the Java notifier with breaking changes to align with current Bugsnag conventions, drop legacy Java/Servlet support, and add new capabilities like feature flags. [#254](https://github.com/bugsnag/bugsnag-java/pull/254)
 * @see [UPGRADING](UPGRADING.md) for upgrade details.

--- a/scripts/docker-publish.sh
+++ b/scripts/docker-publish.sh
@@ -50,7 +50,7 @@ elif [[ "${#REPO_KEYS[@]}" -gt 1 ]]; then
   exit 1
 fi
 
-REPO_KEY="${REPO_KEYS[1]}"
+REPO_KEY="${REPO_KEYS[0]}"
 echo "Closing repository $REPO_KEY..."
 
 URL="https://ossrh-staging-api.central.sonatype.com/manual/upload/repository/$REPO_KEY?publishing_type=user_managed"
@@ -66,7 +66,4 @@ if [[ "$STATUS" != "200" ]]; then
 fi
 
 echo "Repository $REPO_KEY closed successfully."
-
 echo "Go to https://central.sonatype.com/publishing to release the final artefact."
-echo "For full release instructions, visit:"
-echo "https://github.com/bugsnag/bugsnag-java/blob/next/CONTRIBUTING.md#making-a-release"


### PR DESCRIPTION
## Goal
Unblock release by fixing the `docker-publish.sh` script to align with the expected values from OOSRH Staging

## Changeset

- Changed `REPO_KEYS[1]` to `REPO_KEYS[0]`
- Fixed the release date in the CHANGELOG
